### PR TITLE
fix: skip vercel deploy when front is unchanged

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,9 @@
 ---
 更新したら日付や簡単なメモを残す運用がおすすめです。
 更新: 2026-02-03 プロジェクト構成/コマンド/テスト方針を現状に合わせて整理
+更新: 2026-02-05 docs参照による現状把握を実施（Codex作業記録）
+- 参照: `docs/01.requirements.md` 〜 `docs/11.calorie.md`, `docs/error-reports/2026-02-04-runtime-issues.md`, `docs/error-reports/2026-02-04-vercel-build-errors.md`
+- 進捗サマリ: 基盤認証・一般ユーザー機能・管理者主要機能・データ出力・Vercel本番デプロイは完了
+- 未着手: マスター管理の選択肢反映（Issue #6）、プロフィール体重の上書き保存（Issue #8）、ローディング表示統一（Issue #9）、CIでのE2E自動化、base/docs変更時のVercel自動デプロイ抑止（Issue #10）
+- 既知不具合: 2026-02-04時点のランタイム不具合とVercelビルドエラーは `docs/error-reports/` に修正履歴あり
+- 要確認: 同日保存仕様が `docs/05.spec.md`（同日保存はエラー）と `docs/07.e2e-cases.md`（同日保存は上書き）で不整合

--- a/docs/06.tasks.md
+++ b/docs/06.tasks.md
@@ -48,7 +48,8 @@
 | 項目 | 状態 | メモ |
 | --- | --- | --- |
 | Vercel デプロイ | 完了 | `main` ブランチから本番反映 |
-| base/docs 変更時は Vercel 自動デプロイを抑止 | 未着手 | CI/デプロイ条件の見直し（Issue #10） |
+| base/docs 変更時は Vercel 自動デプロイを抑止 | 完了 | `front/vercel.json` の `ignoreCommand` で `front/` 差分なし時にビルド中止（Issue #10） |
 
 更新: 2026-02-04 Vercel デプロイ完了とCI自動化タスクを追記
 更新: 2026-02-04 マスター管理の反映タスクを追加
+更新: 2026-02-05 Issue #10 完了（Vercel ignore 設定を追加）

--- a/front/vercel.json
+++ b/front/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ."
+}


### PR DESCRIPTION
## Summary
- add front/vercel.json with ignoreCommand so Vercel skips build when the commit has no diff under front/
- update deployment task status for Issue #10 in docs/06.tasks.md
- append docs-review work log in AGENTS.md

## Testing
- not run (config/docs change only)

## Issue
- closes #10
