### PR TITLE
[codex] Restrict admin login to ADMIN_EMAIL

### DIFF
--- a/front/src/app/admin/login/page.tsx
+++ b/front/src/app/admin/login/page.tsx
@@ -23,6 +23,29 @@ export default function AdminLoginPage() {
     }
   }, [isAdmin, isLoading, router]);
 
+  useEffect(() => {
+    let mounted = true;
+
+    const rejectNonAdminSession = async () => {
+      if (isLoading || isAdmin) return;
+
+      const { data } = await supabase.auth.getSession();
+      if (!mounted || !data.session) return;
+
+      await supabase.auth.signOut();
+      if (!mounted) return;
+
+      setError('このアカウントでは管理者ログインできません。');
+      setIsWorking(false);
+    };
+
+    void rejectNonAdminSession();
+
+    return () => {
+      mounted = false;
+    };
+  }, [isAdmin, isLoading]);
+
   const handleLogin = async () => {
     setIsWorking(true);
     setError('');

--- a/front/src/app/api/admin/me/route.ts
+++ b/front/src/app/api/admin/me/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '';
+const adminEmail = process.env.ADMIN_EMAIL?.trim().toLowerCase() ?? '';
+
+export async function GET(request: Request) {
+  if (!supabaseUrl || !supabaseAnonKey || !adminEmail) {
+    return NextResponse.json({ error: 'admin auth is not configured' }, { status: 500 });
+  }
+
+  const authHeader = request.headers.get('authorization');
+  const bearer = authHeader?.match(/^Bearer\s+(.+)$/i);
+  const accessToken = bearer?.[1];
+
+  if (!accessToken) {
+    return NextResponse.json({ isAdmin: false }, { status: 401 });
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseAnonKey);
+  const { data, error } = await supabase.auth.getUser(accessToken);
+
+  if (error || !data.user) {
+    return NextResponse.json({ isAdmin: false }, { status: 401 });
+  }
+
+  const userEmail = data.user.email?.trim().toLowerCase() ?? '';
+  const isAdmin = userEmail !== '' && userEmail === adminEmail;
+
+  if (!isAdmin) {
+    return NextResponse.json({ isAdmin: false }, { status: 403 });
+  }
+
+  return NextResponse.json({ isAdmin: true });
+}

--- a/front/src/hooks/useAdminSession.ts
+++ b/front/src/hooks/useAdminSession.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
+import type { Session } from '@supabase/supabase-js';
 import { supabase } from '@/lib/supabase';
 
 const BYPASS_KEY = 'e2e_admin_bypass';
@@ -36,23 +37,62 @@ export function useAdminSession(): AdminSessionState {
 
   useEffect(() => {
     let mounted = true;
+    let requestId = 0;
 
     if (isBypassAllowed) {
       setBypassActive(getBypassFlag());
     }
 
+    const syncAdminFromSession = async (session: Session | null) => {
+      const currentRequestId = ++requestId;
+
+      if (!session?.access_token) {
+        if (!mounted || currentRequestId !== requestId) return;
+        setSessionActive(false);
+        setReady(true);
+        return;
+      }
+
+      try {
+        const response = await fetch('/api/admin/me', {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${session.access_token}`,
+          },
+          cache: 'no-store',
+        });
+
+        if (!mounted || currentRequestId !== requestId) return;
+        if (!response.ok) {
+          setSessionActive(false);
+          setReady(true);
+          return;
+        }
+
+        const data = (await response.json().catch(() => null)) as { isAdmin?: boolean } | null;
+        setSessionActive(Boolean(data?.isAdmin));
+      } catch {
+        if (!mounted || currentRequestId !== requestId) return;
+        setSessionActive(false);
+      } finally {
+        if (!mounted || currentRequestId !== requestId) return;
+        setReady(true);
+      }
+    };
+
     const syncSession = async () => {
       const { data } = await supabase.auth.getSession();
       if (!mounted) return;
-      setSessionActive(Boolean(data.session));
-      setReady(true);
+      setReady(false);
+      await syncAdminFromSession(data.session);
     };
 
     void syncSession();
 
     const { data: authListener } = supabase.auth.onAuthStateChange((_event, session) => {
       if (!mounted) return;
-      setSessionActive(Boolean(session));
+      setReady(false);
+      void syncAdminFromSession(session);
     });
 
     return () => {


### PR DESCRIPTION
## Summary
This change removes implicit admin access for any authenticated Google account and restricts admin access to a single configured email address.

## Problem
Admin access was determined only by whether a Supabase session existed on the client. As a result, any user who could sign in via Google OAuth could be treated as admin in the UI.

## Root Cause
`useAdminSession` used `Boolean(session)` as the admin gate. There was no server-side email check in the admin session flow.

## Fix
- Added `GET /api/admin/me` to validate the logged-in user with Supabase and compare `user.email` to `ADMIN_EMAIL`.
- Updated `useAdminSession` to call `/api/admin/me` with the session access token and derive `isAdmin` from that response.
- Updated `/admin/login` to sign out and show an error when a non-admin account signs in.
- Removed dependency on `NEXT_PUBLIC_ADMIN_EMAIL` (now only `ADMIN_EMAIL` is used).

## User Impact
- Only the configured admin email can access `/admin` routes.
- Non-admin Google accounts can still attempt login, but are signed out and shown an access error.

## Validation
- `cd front && pnpm run build` passed.
- Attempted Playwright run, but existing environment issue prevented execution (`Can't resolve 'tailwindcss'` from workspace root in webServer startup).
