### PR TITLE
feat: 記録詳細画面から編集画面への導線を追加 (#18)

### DIFF
--- a/front/src/components/RecordDetailClient.tsx
+++ b/front/src/components/RecordDetailClient.tsx
@@ -7,6 +7,7 @@ import PageHeader from '@/components/ui/PageHeader';
 import { buttonClasses } from '@/components/ui/Button';
 import LoadingSpinner from '@/components/ui/LoadingSpinner';
 import CalorieEstimate from '@/components/CalorieEstimate';
+import { useAdminSession } from '@/hooks/useAdminSession';
 
 export type DetailWorkout = {
   id: string;
@@ -36,6 +37,7 @@ export default function RecordDetailClient({ date }: RecordDetailClientProps) {
   const [detail, setDetail] = useState<RecordDetailData | null>(null);
   const [errorMessage, setErrorMessage] = useState('');
   const [isLoading, setIsLoading] = useState(true);
+  const { isAdmin } = useAdminSession();
 
   useEffect(() => {
     const fetchDetail = async () => {
@@ -101,8 +103,20 @@ export default function RecordDetailClient({ date }: RecordDetailClientProps) {
           {!isLoading && !errorMessage ? (
             <>
               <Card className="p-6 md:p-8">
-                <p className="text-[10px] font-black uppercase tracking-[0.2em] text-gray-400">日付</p>
-                <h2 className="text-2xl font-black text-gray-900">{detail?.date ?? date}</h2>
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-[10px] font-black uppercase tracking-[0.2em] text-gray-400">日付</p>
+                    <h2 className="text-2xl font-black text-gray-900">{detail?.date ?? date}</h2>
+                  </div>
+                  {isAdmin ? (
+                    <Link
+                      href={`/admin/records/${detail?.date ?? date}/edit`}
+                      className="rounded-full border border-[#8a6f3c] px-4 py-2 text-sm font-bold text-[#8a6f3c] transition hover:bg-[#8a6f3c] hover:text-white"
+                    >
+                      編集
+                    </Link>
+                  ) : null}
+                </div>
               </Card>
 
               <Card className="p-6">

--- a/front/tests/e2e/smoke.spec.ts
+++ b/front/tests/e2e/smoke.spec.ts
@@ -18,6 +18,28 @@ test('detail page renders sections', async ({ page }) => {
   await expect(page.getByText('筋トレ')).toBeVisible();
   await expect(page.getByText('有酸素')).toBeVisible();
   await expect(page.getByRole('heading', { name: '体調メモ' })).toBeVisible();
+
+  // Non-admin: edit button should NOT be visible
+  await expect(page.getByRole('link', { name: '編集' })).not.toBeVisible();
+});
+
+test('detail page shows edit button for admin and navigates to edit page', async ({ page }) => {
+  // Login as admin
+  await page.goto('/admin/login');
+  await page.getByRole('button', { name: 'テストログイン' }).click();
+
+  // Navigate to detail page
+  await page.goto('/records/2026-02-02');
+  await expect(page.getByRole('heading', { name: '記録詳細' })).toBeVisible();
+
+  // Admin: edit button should be visible
+  const editLink = page.getByRole('link', { name: '編集' });
+  await expect(editLink).toBeVisible();
+
+  // Click edit and verify navigation to edit page
+  await editLink.click();
+  await expect(page).toHaveURL(/\/admin\/records\/2026-02-02\/edit/);
+  await expect(page.getByRole('heading', { name: '記録編集' })).toBeVisible();
 });
 
 test('admin pages render', async ({ page }) => {


### PR DESCRIPTION
## Summary
- 記録詳細画面に管理者のみ「編集」ボタンを表示
- クリックで `/admin/records/{date}/edit` に遷移
- 一般ユーザーには編集ボタンを表示しない

## Test plan
- [x] ビルド成功確認
- [ ] E2E: 未ログイン時に編集ボタンが非表示
- [ ] E2E: 管理者ログイン後に編集ボタン表示→クリック→編集画面に遷移

## 既知の制限
- 保存後/戻り先が `/admin/records` になる（#32 で対応予定）

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)