### PR TITLE
feat: 記録一覧にページング機能を追加（1ページ10件）(#24)

### DIFF
--- a/docs/10.api.md
+++ b/docs/10.api.md
@@ -16,19 +16,18 @@
 ### GET /records
 - 用途: 一覧取得
 - 並び順: 日付の新しい順（降順）
-- クエリ: `page=1&limit=10`（ページング対応）
-- 返却項目（最小）:
-  - date
-  - memo
-  - workouts (part/name/sets/reps/weight)
-  - cardios (type/minutes/distance) ※複数行
-  - totalSets
-  - totalCalories
-- ページング情報:
-  - totalCount
-  - page
-  - limit
-  - totalPages
+- クエリ: `page=N`（1始まり、limit=10 固定）
+- `page` 未指定/NaN/0以下 → 1 に正規化
+- `page > totalPages` → 最終ページに clamp
+- レスポンス形式:
+  ```json
+  {
+    "records": [{ date, totalSets, cardioMinutes, cardioDistance, cardios }],
+    "totalCount": 25,
+    "page": 1,
+    "totalPages": 3
+  }
+  ```
 
 ### GET /records/:date
 - 用途: 詳細取得

--- a/front/src/app/admin/records/page.tsx
+++ b/front/src/app/admin/records/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from 'react';
 import AdminRecordsListClient from '@/components/AdminRecordsListClient';
 
 export default function AdminRecordsPage() {
-  return <AdminRecordsListClient />;
+  return (
+    <Suspense>
+      <AdminRecordsListClient />
+    </Suspense>
+  );
 }

--- a/front/src/app/api/records/route.ts
+++ b/front/src/app/api/records/route.ts
@@ -1,14 +1,27 @@
 import { NextResponse } from 'next/server';
 import { getPrisma } from '@/lib/prisma';
 
-export async function GET() {
+const PAGE_LIMIT = 10;
+
+export async function GET(request: Request) {
   const prisma = getPrisma();
   if (!prisma) {
     return NextResponse.json({ error: 'database unavailable' }, { status: 503 });
   }
+
+  const { searchParams } = new URL(request.url);
+  const totalCount = await prisma.exerciseRecord.count();
+  const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_LIMIT));
+
+  let page = Math.floor(Number(searchParams.get('page') ?? 1));
+  if (Number.isNaN(page) || page < 1) page = 1;
+  if (page > totalPages) page = totalPages;
+
   const records = await prisma.exerciseRecord.findMany({
     orderBy: { date: 'desc' },
     include: { workouts: true, cardios: true },
+    skip: (page - 1) * PAGE_LIMIT,
+    take: PAGE_LIMIT,
   });
 
   const result = records.map(
@@ -29,7 +42,7 @@ export async function GET() {
   }),
   );
 
-  return NextResponse.json(result);
+  return NextResponse.json({ records: result, totalCount, page, totalPages });
 }
 
 export async function POST(request: Request) {

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from 'react';
 import RecordsListClient from '@/components/RecordsListClient';
 
 export default function HomePage() {
-  return <RecordsListClient />;
+  return (
+    <Suspense>
+      <RecordsListClient />
+    </Suspense>
+  );
 }

--- a/front/src/components/AdminRecordsListClient.tsx
+++ b/front/src/components/AdminRecordsListClient.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { Plus } from 'lucide-react';
 import Card from '@/components/ui/Card';
 import PageHeader from '@/components/ui/PageHeader';
@@ -16,33 +17,55 @@ export type AdminRecordSummary = {
 };
 
 export default function AdminRecordsListClient() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const [records, setRecords] = useState<AdminRecordSummary[]>([]);
   const [deletingDate, setDeletingDate] = useState<string | null>(null);
   const [error, setError] = useState('');
   const [hasFetched, setHasFetched] = useState(false);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
 
-  useEffect(() => {
-    const fetchRecords = async () => {
-      try {
-        const res = await fetch('/api/records');
-        if (!res.ok) {
-          setError('記録の取得に失敗しました。');
-          setRecords([]);
-          setHasFetched(true);
-          return;
-        }
-        const data = (await res.json()) as AdminRecordSummary[];
-        setRecords(data);
-        setHasFetched(true);
-      } catch {
+  const currentPage = Number(searchParams.get('page') ?? 1) || 1;
+
+  const fetchRecords = useCallback(async (p: number) => {
+    setHasFetched(false);
+    try {
+      const res = await fetch(`/api/records?page=${p}`);
+      if (!res.ok) {
         setError('記録の取得に失敗しました。');
         setRecords([]);
         setHasFetched(true);
+        return;
       }
-    };
+      const data = (await res.json()) as {
+        records: AdminRecordSummary[];
+        page: number;
+        totalPages: number;
+      };
+      setRecords(data.records);
+      setPage(data.page);
+      setTotalPages(data.totalPages);
+      setHasFetched(true);
 
-    void fetchRecords();
-  }, []);
+      if (data.page !== p) {
+        router.replace(`/admin/records?page=${data.page}`);
+      }
+    } catch {
+      setError('記録の取得に失敗しました。');
+      setRecords([]);
+      setHasFetched(true);
+    }
+  }, [router]);
+
+  useEffect(() => {
+    void fetchRecords(currentPage);
+  }, [currentPage, fetchRecords]);
+
+  const goToPage = (p: number) => {
+    window.scrollTo({ top: 0 });
+    router.push(`/admin/records?page=${p}`);
+  };
 
   const handleDelete = async (date: string) => {
     if (!confirm('この記録を削除しますか？')) return;
@@ -54,8 +77,27 @@ export default function AdminRecordsListClient() {
       setDeletingDate(null);
       return;
     }
-    setRecords((prev) => prev.filter((record) => record.date !== date));
     setDeletingDate(null);
+    // Re-fetch current page; if empty and not first page, go to previous page
+    const refetchRes = await fetch(`/api/records?page=${page}`);
+    if (refetchRes.ok) {
+      const data = (await refetchRes.json()) as {
+        records: AdminRecordSummary[];
+        page: number;
+        totalPages: number;
+      };
+      if (data.records.length === 0 && data.page > 1) {
+        goToPage(data.page - 1);
+      } else {
+        setRecords(data.records);
+        setPage(data.page);
+        setTotalPages(data.totalPages);
+        // Correct URL if API clamped the page
+        if (data.page !== page) {
+          router.replace(`/admin/records?page=${data.page}`);
+        }
+      }
+    }
   };
 
   return (
@@ -95,7 +137,7 @@ export default function AdminRecordsListClient() {
               </p>
             </Card>
           ) : null}
-          {records.map((record) => (
+          {records.length > 0 && records.map((record) => (
             <Card key={record.date} className="p-6 md:p-8">
               <div className="flex flex-wrap items-center justify-between gap-4">
                 <div>
@@ -148,6 +190,30 @@ export default function AdminRecordsListClient() {
               </div>
             </Card>
           ))}
+
+          {hasFetched && totalPages > 1 ? (
+            <div className="mt-8 flex items-center justify-center gap-4">
+              <button
+                type="button"
+                className={buttonClasses('outline')}
+                onClick={() => goToPage(page - 1)}
+                disabled={page <= 1}
+              >
+                前へ
+              </button>
+              <span className="text-sm font-bold text-gray-600">
+                {page} / {totalPages} ページ
+              </span>
+              <button
+                type="button"
+                className={buttonClasses('outline')}
+                onClick={() => goToPage(page + 1)}
+                disabled={page >= totalPages}
+              >
+                次へ
+              </button>
+            </div>
+          ) : null}
         </div>
       </section>
     </main>

--- a/front/src/components/RecordsListClient.tsx
+++ b/front/src/components/RecordsListClient.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { CalendarDays, Plus } from 'lucide-react';
 import Card from '@/components/ui/Card';
 import PageHeader from '@/components/ui/PageHeader';
@@ -21,34 +22,57 @@ export type RecordSummary = {
 };
 
 export default function RecordsListClient() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const [records, setRecords] = useState<RecordSummary[]>([]);
   const [hasFetched, setHasFetched] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
   const { isAdmin } = useAdminSession();
 
-  useEffect(() => {
-    const fetchRecords = async () => {
-      try {
-        const res = await fetch('/api/records');
-        if (!res.ok) {
-          setErrorMessage('記録の取得に失敗しました。');
-          setRecords([]);
-          setHasFetched(true);
-          return;
-        }
-        const data = (await res.json()) as RecordSummary[];
-        setErrorMessage('');
-        setRecords(data);
-        setHasFetched(true);
-      } catch {
+  const currentPage = Number(searchParams.get('page') ?? 1) || 1;
+
+  const fetchRecords = useCallback(async (p: number) => {
+    setHasFetched(false);
+    try {
+      const res = await fetch(`/api/records?page=${p}`);
+      if (!res.ok) {
         setErrorMessage('記録の取得に失敗しました。');
         setRecords([]);
         setHasFetched(true);
+        return;
       }
-    };
+      const data = (await res.json()) as {
+        records: RecordSummary[];
+        page: number;
+        totalPages: number;
+      };
+      setErrorMessage('');
+      setRecords(data.records);
+      setPage(data.page);
+      setTotalPages(data.totalPages);
+      setHasFetched(true);
 
-    void fetchRecords();
-  }, []);
+      // Correct URL if API clamped the page
+      if (data.page !== p) {
+        router.replace(data.page === 1 ? '/' : `/?page=${data.page}`);
+      }
+    } catch {
+      setErrorMessage('記録の取得に失敗しました。');
+      setRecords([]);
+      setHasFetched(true);
+    }
+  }, [router]);
+
+  useEffect(() => {
+    void fetchRecords(currentPage);
+  }, [currentPage, fetchRecords]);
+
+  const goToPage = (p: number) => {
+    window.scrollTo({ top: 0 });
+    router.push(p === 1 ? '/' : `/?page=${p}`);
+  };
 
   return (
     <main className="min-h-screen pb-16">
@@ -147,6 +171,30 @@ export default function RecordsListClient() {
               </Card>
             ))
           )}
+
+          {hasFetched && totalPages > 1 ? (
+            <div className="mt-8 flex items-center justify-center gap-4">
+              <button
+                type="button"
+                className={buttonClasses('outline')}
+                onClick={() => goToPage(page - 1)}
+                disabled={page <= 1}
+              >
+                前へ
+              </button>
+              <span className="text-sm font-bold text-gray-600">
+                {page} / {totalPages} ページ
+              </span>
+              <button
+                type="button"
+                className={buttonClasses('outline')}
+                onClick={() => goToPage(page + 1)}
+                disabled={page >= totalPages}
+              >
+                次へ
+              </button>
+            </div>
+          ) : null}
         </div>
       </section>
     </main>

--- a/front/tests/e2e/smoke.spec.ts
+++ b/front/tests/e2e/smoke.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-test('list page renders core elements', async ({ page }) => {
+test('list page renders core elements and pagination', async ({ page }) => {
   await page.goto('/');
   await expect(page.getByRole('heading', { name: '記録一覧' })).toBeVisible();
   await expect(page.getByRole('link', { name: '管理者ログイン' })).toBeVisible();
@@ -9,6 +9,26 @@ test('list page renders core elements', async ({ page }) => {
   await expect(page.getByText('有酸素合計時間').first()).toBeVisible();
   await expect(page.getByText('有酸素合計距離').first()).toBeVisible();
   await expect(page.getByText('推定消費カロリー').first()).toBeVisible();
+
+  // Pagination: verify API returns paging structure
+  const res = await page.request.get('/api/records?page=1');
+  const data = await res.json();
+  // API should return { records, totalCount, page, totalPages }
+  expect(data).toHaveProperty('records');
+  expect(data).toHaveProperty('totalCount');
+  expect(data).toHaveProperty('page', 1);
+  expect(data).toHaveProperty('totalPages');
+
+  // If multiple pages, verify pagination UI
+  if (data.totalPages > 1) {
+    const prevButton = page.getByRole('button', { name: '前へ' });
+    const nextButton = page.getByRole('button', { name: '次へ' });
+    // First page: "前へ" should be disabled
+    await expect(prevButton).toBeDisabled();
+    // Click "次へ" and verify URL changes to ?page=2
+    await nextButton.click();
+    await expect(page).toHaveURL(/[?&]page=2/);
+  }
 });
 
 test('detail page renders sections', async ({ page }) => {


### PR DESCRIPTION
## Summary
- `GET /api/records` に `page` クエリ対応（`limit=10` 固定、`page > totalPages` は clamp）
- 一般一覧・管理者一覧に前へ/次へボタン付きページングUI
- URLクエリ `?page=N` に同期（リロード・ブラウザ戻るでもページ維持）
- 管理者一覧の削除後に再fetch + 空ページ時は前ページへ遷移 + URL補正

## Test plan
- [x] ビルド成功確認
- [ ] E2E: APIレスポンスに `records`/`totalCount`/`page`/`totalPages` が含まれること
- [ ] E2E: 複数ページ時に前へ非活性 + 次へ押下で `?page=2` に遷移

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)