### PR TITLE
fix: DB接続プール枯渇を修正（getPrismaキャッシュ）

### DIFF
--- a/front/src/lib/prisma.ts
+++ b/front/src/lib/prisma.ts
@@ -20,9 +20,7 @@ export function getPrisma() {
     const pool = new Pool({ connectionString: process.env.DATABASE_URL });
     const adapter = new PrismaPg(pool);
     const client = new PrismaClient({ adapter, log: ['error'] });
-    if (process.env.NODE_ENV !== 'production') {
-      globalForPrisma.prisma = client;
-    }
+    globalForPrisma.prisma = client;
     return client;
   } catch {
     globalForPrisma.prisma = null;


### PR DESCRIPTION
## Summary
- `getPrisma()` が本番環境でPrismaClientをキャッシュしていなかったため、リクエストごとに新しい `pg.Pool` が作成されDB接続がリークしていた
- `MaxClientsInSession` エラーで全APIが500を返す状態に
- 環境に関わらず `globalThis` にキャッシュするよう修正（1行変更）

## Test plan
- [ ] デプロイ後、GET /api/records が正常に200を返すか確認
- [ ] 記録追加（ラン＋ウォーク複数行）が成功するか確認
- [ ] 連続アクセスしても MaxClientsInSession エラーが出ないか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)