### PR TITLE
docs(front): ESLint に JSDoc ルールを導入し公開シンボルへ JSDoc を付与

### DIFF
--- a/.claude/rules/jsdoc.md
+++ b/.claude/rules/jsdoc.md
@@ -54,6 +54,13 @@ export async function resolveDisplayName(
 }
 ```
 
-## Lint による強制（推奨）
+## Lint による強制（導入済み）
 
-`eslint-plugin-jsdoc` を導入し、公開シンボルへの JSDoc 欠落・`@param` / `@returns` 漏れを CI で検出する。TypeScript プロジェクトでは型ブレース系ルールを無効化する（`jsdoc/require-param-type` / `jsdoc/require-returns-type` を off）。
+`eslint-plugin-jsdoc` を導入済み（`front/eslint.config.mjs`）。有効ルールの唯一の真実は同ファイルの JSDoc ブロック。機械判定できる部分のみ強制する。
+
+- `jsdoc/no-types`（error）— 型の再掲を禁止（TS シグネチャが型の唯一の真実）。
+- `jsdoc/require-param` / `require-param-description` / `check-param-names`（error）— JSDoc ブロックを持つ関数は全引数を `@param` で説明し、名前・順序・過不足を突き合わせる（分割代入 props は展開しない）。
+- `jsdoc/require-returns` / `require-returns-description`（error）— 戻り値がある関数は `@returns` に意味を書く。**JSX を返す `.tsx` コンポーネントは除外**（`@returns …の要素` はノイズのため）。
+- `jsdoc/check-alignment` / `no-multi-asterisks`（warn）— 体裁を整える。
+
+`require-jsdoc` は行コメントを誤検知するため未採用（JSDoc ブロックの有無・質はレビューで確認する）。Prisma 自動生成コード（`src/generated/**`）は lint 対象外。

--- a/front/eslint.config.mjs
+++ b/front/eslint.config.mjs
@@ -1,10 +1,45 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
+import jsdoc from "eslint-plugin-jsdoc";
 
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  // JSDoc 規約（TSDoc スタイル）の機械的に判定できる部分を強制する。
+  // 有効ルールの唯一の真実はこのブロック。方針の根拠は .claude/rules/jsdoc.md。
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    plugins: { jsdoc },
+    // TS 前提。型は JSDoc ではなくシグネチャに委ねる。
+    settings: { jsdoc: { mode: "typescript" } },
+    rules: {
+      // 型の再掲を禁止（TS シグネチャが型の唯一の真実）。
+      "jsdoc/no-types": "error",
+      // JSDoc ブロックを持つ関数は全引数を @param で説明する。
+      // 分割代入 props は型（XxxProps）が真実なので props.x 単位には展開しない。
+      "jsdoc/require-param": ["error", { checkDestructured: false, checkDestructuredRoots: false }],
+      "jsdoc/require-param-description": "error",
+      // @param 名と実引数名を突き合わせる（名前ズレ・順序・過不足を検出）。
+      "jsdoc/check-param-names": "error",
+      // 返り値がある関数は @returns に意味を書く（.tsx コンポーネントは後続ブロックで除外）。
+      "jsdoc/require-returns": "error",
+      "jsdoc/require-returns-description": "error",
+      // 書いた JSDoc の体裁を整える。
+      "jsdoc/check-alignment": "warn",
+      "jsdoc/no-multi-asterisks": "warn",
+      // require-jsdoc は // 行コメントを誤検知するため未採用。ブロックの有無・質はレビューで確認する。
+    },
+  },
+  {
+    // React コンポーネント（JSX を返す .tsx）は @returns を要求しない（「@returns …の要素」はノイズ）。
+    // .ts のフック / lib / API では @returns 必須のまま。
+    files: ["src/**/*.tsx"],
+    rules: {
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off",
+    },
+  },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:
@@ -12,6 +47,9 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Prisma 自動生成コード（.gitignore 済みのビルド成果物）は lint 対象外にする。
+    // JSDoc/型ルール等が生成コードを誤検知するため除外する。
+    "src/generated/**",
   ]),
 ]);
 

--- a/front/package.json
+++ b/front/package.json
@@ -45,6 +45,7 @@
     "babel-plugin-react-compiler": "1.0.0",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
+    "eslint-plugin-jsdoc": "^63.0.12",
     "jsdom": "^29.0.1",
     "prettier": "^3.8.1",
     "prisma": "^6.19.2",

--- a/front/pnpm-lock.yaml
+++ b/front/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       eslint-config-next:
         specifier: 16.1.6
         version: 16.1.6(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      eslint-plugin-jsdoc:
+        specifier: ^63.0.12
+        version: 63.0.12(eslint@9.39.2(jiti@2.6.1))
       jsdom:
         specifier: ^29.0.1
         version: 29.0.1
@@ -230,6 +233,14 @@ packages:
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@es-joy/jsdoccomment@0.88.0':
+    resolution: {integrity: sha512-GK/HL/claLLNo5KG705auIlZMwEtmn88ofSGuLsmVZwKBqMPJhW9DiznYNq07QEqz9BPtA3LBfYImtZmhVvRAw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@es-joy/resolve.exports@1.2.0':
+    resolution: {integrity: sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==}
+    engines: {node: '>=10'}
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -694,6 +705,10 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
+  '@sindresorhus/base62@1.0.0':
+    resolution: {integrity: sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==}
+    engines: {node: '>=18'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -860,6 +875,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -926,6 +944,10 @@ packages:
 
   '@typescript-eslint/types@8.54.0':
     resolution: {integrity: sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/types@8.63.0':
+    resolution: {integrity: sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.54.0':
@@ -1100,6 +1122,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
@@ -1114,6 +1141,10 @@ packages:
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  are-docs-informative@0.0.2:
+    resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
+    engines: {node: '>=14'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1262,6 +1293,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  comment-parser@1.4.7:
+    resolution: {integrity: sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==}
+    engines: {node: '>= 12.0.0'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -1496,6 +1531,12 @@ packages:
       '@typescript-eslint/parser':
         optional: true
 
+  eslint-plugin-jsdoc@63.0.12:
+    resolution: {integrity: sha512-99VfBHyoLlF9n5w9wh+jLWDBzCgYd3tfw3M/aynAd+H2ylGHWLbde/GPTuo/5az3jMAN0fH7QzCYvEOY6u+Ypg==}
+    engines: {node: ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
+
   eslint-plugin-jsx-a11y@6.10.2:
     resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
     engines: {node: '>=4.0'}
@@ -1526,6 +1567,10 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   eslint@9.39.2:
     resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1539,6 +1584,10 @@ packages:
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
@@ -1729,6 +1778,9 @@ packages:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  html-entities@2.6.0:
+    resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
+
   iceberg-js@0.8.1:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
     engines: {node: '>=20.0.0'}
@@ -1883,6 +1935,10 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdoc-type-pratt-parser@7.2.0:
+    resolution: {integrity: sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==}
+    engines: {node: '>=20.0.0'}
 
   jsdom@29.0.1:
     resolution: {integrity: sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==}
@@ -2193,6 +2249,9 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-deep-merge@2.0.1:
+    resolution: {integrity: sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -2246,6 +2305,12 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-imports-exports@0.2.4:
+    resolution: {integrity: sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==}
+
+  parse-statements@1.0.11:
+    resolution: {integrity: sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==}
 
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
@@ -2439,6 +2504,10 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  reserved-identifiers@1.2.0:
+    resolution: {integrity: sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==}
+    engines: {node: '>=18'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2495,6 +2564,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -2541,6 +2615,15 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@4.0.0:
+    resolution: {integrity: sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==}
+
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
@@ -2650,6 +2733,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  to-valid-identifier@1.0.0:
+    resolution: {integrity: sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==}
+    engines: {node: '>=20'}
 
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
@@ -3059,6 +3146,16 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@es-joy/jsdoccomment@0.88.0':
+    dependencies:
+      '@types/estree': 1.0.9
+      '@typescript-eslint/types': 8.63.0
+      comment-parser: 1.4.7
+      esquery: 1.7.0
+      jsdoc-type-pratt-parser: 7.2.0
+
+  '@es-joy/resolve.exports@1.2.0': {}
+
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1))':
     dependencies:
       eslint: 9.39.2(jiti@2.6.1)
@@ -3401,6 +3498,8 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
+  '@sindresorhus/base62@1.0.0': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@supabase/auth-js@2.94.0':
@@ -3564,6 +3663,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/estree@1.0.9': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -3651,6 +3752,8 @@ snapshots:
       - supports-color
 
   '@typescript-eslint/types@8.54.0': {}
+
+  '@typescript-eslint/types@8.63.0': {}
 
   '@typescript-eslint/typescript-estree@8.54.0(typescript@5.9.3)':
     dependencies:
@@ -3794,7 +3897,13 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
+  acorn-jsx@5.3.2(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
   acorn@8.15.0: {}
+
+  acorn@8.17.0: {}
 
   ajv@6.12.6:
     dependencies:
@@ -3810,6 +3919,8 @@ snapshots:
       color-convert: 2.0.1
 
   ansi-styles@5.2.0: {}
+
+  are-docs-informative@0.0.2: {}
 
   argparse@2.0.1: {}
 
@@ -3993,6 +4104,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  comment-parser@1.4.7: {}
 
   concat-map@0.0.1: {}
 
@@ -4302,6 +4415,26 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
+  eslint-plugin-jsdoc@63.0.12(eslint@9.39.2(jiti@2.6.1)):
+    dependencies:
+      '@es-joy/jsdoccomment': 0.88.0
+      '@es-joy/resolve.exports': 1.2.0
+      are-docs-informative: 0.0.2
+      comment-parser: 1.4.7
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint: 9.39.2(jiti@2.6.1)
+      espree: 11.2.0
+      esquery: 1.7.0
+      html-entities: 2.6.0
+      object-deep-merge: 2.0.1
+      parse-imports-exports: 0.2.4
+      semver: 7.8.5
+      spdx-expression-parse: 4.0.0
+      to-valid-identifier: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       aria-query: 5.3.2
@@ -4363,6 +4496,8 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
+  eslint-visitor-keys@5.0.1: {}
+
   eslint@9.39.2(jiti@2.6.1):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
@@ -4409,6 +4544,12 @@ snapshots:
       acorn: 8.15.0
       acorn-jsx: 5.3.2(acorn@8.15.0)
       eslint-visitor-keys: 4.2.1
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      eslint-visitor-keys: 5.0.1
 
   esquery@1.7.0:
     dependencies:
@@ -4595,6 +4736,8 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  html-entities@2.6.0: {}
+
   iceberg-js@0.8.1: {}
 
   ignore@5.3.2: {}
@@ -4750,6 +4893,8 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdoc-type-pratt-parser@7.2.0: {}
 
   jsdom@29.0.1:
     dependencies:
@@ -5006,6 +5151,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-deep-merge@2.0.1: {}
+
   object-inspect@1.13.4: {}
 
   object-keys@1.1.1: {}
@@ -5076,6 +5223,12 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-imports-exports@0.2.4:
+    dependencies:
+      parse-statements: 1.0.11
+
+  parse-statements@1.0.11: {}
 
   parse5@8.0.0:
     dependencies:
@@ -5256,6 +5409,8 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  reserved-identifiers@1.2.0: {}
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -5330,6 +5485,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.3: {}
+
+  semver@7.8.5: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -5422,6 +5579,15 @@ snapshots:
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@4.0.0:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
+  spdx-license-ids@3.0.23: {}
 
   split2@4.2.0: {}
 
@@ -5533,6 +5699,11 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  to-valid-identifier@1.0.0:
+    dependencies:
+      '@sindresorhus/base62': 1.0.0
+      reserved-identifiers: 1.2.0
 
   tough-cookie@6.0.1:
     dependencies:

--- a/front/src/app/admin/AdminLayoutClient.tsx
+++ b/front/src/app/admin/AdminLayoutClient.tsx
@@ -10,6 +10,13 @@ import {
 } from '@/hooks/useAdminSession';
 import LoadingSpinner from '@/components/ui/LoadingSpinner';
 
+/**
+ * 管理者エリアの認証ガード兼レイアウト。管理者セッションの有無を判定し、未ログインなら
+ * ログイン画面へリダイレクトする。ログイン画面（`/admin/login`）自体、E2E バイパス有効時、
+ * および判定中ローディング表示は例外として通過・表示する。`?bypass=1` を検出した場合は
+ * バイパスフラグを保存してクエリを除去する。`children` は管理者と判定された場合に描画する
+ * 管理画面の内容。
+ */
 export default function AdminLayoutClient({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();

--- a/front/src/app/admin/export/page.tsx
+++ b/front/src/app/admin/export/page.tsx
@@ -10,6 +10,11 @@ import LoadingSpinner from '@/components/ui/LoadingSpinner';
 import DatePicker from '@/components/DatePicker';
 import { authFetch } from '@/lib/authFetch';
 
+/**
+ * データ出力画面。From/To の期間と出力形式（CSV / JSON）を指定して記録をエクスポートする。
+ * API から取得したデータを Blob 化し、ブラウザのダウンロードを起動する。期間未選択や取得
+ * 失敗はメッセージで通知する。（Issue #20 で削除予定、現時点では現役）
+ */
 export default function AdminExportPage() {
   const [fromDate, setFromDate] = useState('');
   const [toDate, setToDate] = useState('');

--- a/front/src/app/admin/layout.tsx
+++ b/front/src/app/admin/layout.tsx
@@ -1,6 +1,11 @@
 import { Suspense } from 'react';
 import AdminLayoutClient from './AdminLayoutClient';
 
+/**
+ * 管理者エリア（`/admin/*`）のレイアウト。認証ガードを担う `AdminLayoutClient` を
+ * `Suspense` 境界内で描画する。`AdminLayoutClient` が `useSearchParams` を利用するため
+ * Suspense でラップしている。`children` は認証ガードを通過した後に描画する管理画面の内容。
+ */
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
   return (
     <Suspense fallback={null}>

--- a/front/src/app/admin/login/page.tsx
+++ b/front/src/app/admin/login/page.tsx
@@ -10,6 +10,11 @@ import LoadingSpinner from '@/components/ui/LoadingSpinner';
 import { supabase } from '@/lib/supabase';
 import { isBypassAllowed, setBypassSession, useAdminSession } from '@/hooks/useAdminSession';
 
+/**
+ * 管理者ログイン画面。Google OAuth（Supabase Auth）でのログインを提供する。既に管理者
+ * 判定済みなら管理者メニューへ、管理者でないセッションが残っている場合はサインアウトして
+ * エラーを表示する。非本番環境ではテストログイン（E2E バイパス）ボタンも表示する。
+ */
 export default function AdminLoginPage() {
   const router = useRouter();
   const { isAdmin, isLoading } = useAdminSession();

--- a/front/src/app/admin/masters/page.tsx
+++ b/front/src/app/admin/masters/page.tsx
@@ -9,20 +9,31 @@ import { buttonClasses } from '@/components/ui/Button';
 import LoadingSpinner from '@/components/ui/LoadingSpinner';
 import { authFetch } from '@/lib/authFetch';
 
+/** マスター管理画面のタブ定義（表示ラベルと API のマスター種別）。 */
 const masterTabs = [
   { label: '部位', type: 'body-parts' },
   { label: '種目', type: 'exercises' },
   { label: '有酸素種別', type: 'cardio-types' },
 ] as const;
 
+/** マスター種別の識別子。`masterTabs` の `type` から導出する。 */
 type MasterType = (typeof masterTabs)[number]['type'];
 
+/** マスター項目 1 件を表す。 */
 type MasterItem = {
+  /** 項目の一意 ID。 */
   id: string;
+  /** 項目の名称（一覧表示・編集対象）。 */
   name: string;
+  /** 所属するマスター種別。 */
   type: MasterType;
 };
 
+/**
+ * マスター管理画面。部位・種目・有酸素種別のタブを切り替えて項目を一覧表示し、追加・
+ * インライン編集・削除（確認ダイアログ付き）を行う。取得・追加・保存・削除は API 経由で、
+ * 名称重複（409）や各操作の失敗はステータスメッセージで通知する。
+ */
 export default function AdminMastersPage() {
   const [activeType, setActiveType] = useState<MasterType>('body-parts');
   const [items, setItems] = useState<MasterItem[]>([]);

--- a/front/src/app/admin/page.tsx
+++ b/front/src/app/admin/page.tsx
@@ -9,6 +9,7 @@ import { buttonClasses } from '@/components/ui/Button';
 import { supabase } from '@/lib/supabase';
 import { setBypassSession } from '@/hooks/useAdminSession';
 
+/** 管理者メニューに並べるカードの定義（表示ラベル・遷移先パス・アイコン）。 */
 const menuItems = [
   { label: '記録一覧', href: '/admin/records', icon: ListOrdered },
   { label: '記録追加', href: '/admin/records/new', icon: FilePlus },
@@ -17,6 +18,11 @@ const menuItems = [
   { label: 'データ出力', href: '/admin/export', icon: Upload },
 ];
 
+/**
+ * 管理者メニュー画面。記録一覧・記録追加・プロフィール・マスター管理・データ出力への
+ * 導線をカードのグリッドで表示し、右上にログアウトボタンを固定表示する。ログアウト時は
+ * E2E バイパスフラグを解除し Supabase からサインアウトしてログイン画面へ遷移する。
+ */
 export default function AdminMenuPage() {
   const router = useRouter();
 

--- a/front/src/app/admin/profile/page.tsx
+++ b/front/src/app/admin/profile/page.tsx
@@ -9,6 +9,11 @@ import LoadingSpinner from '@/components/ui/LoadingSpinner';
 import { authFetch } from '@/lib/authFetch';
 import Link from 'next/link';
 
+/**
+ * プロフィール画面。体重（kg）を入力・保存する。表示時に保存済みの体重を取得してプリセットし、
+ * 保存値は消費カロリー計算に使用する。数値以外の入力は保存せずエラー表示にする。データは
+ * 1 件のみ維持（上書き保存）。
+ */
 export default function AdminProfilePage() {
   const [weightKg, setWeightKg] = useState('');
   const [isFetching, setIsFetching] = useState(true);

--- a/front/src/app/admin/records/[date]/edit/page.tsx
+++ b/front/src/app/admin/records/[date]/edit/page.tsx
@@ -12,33 +12,58 @@ import DatePicker from '@/components/DatePicker';
 import { useRecordValidation } from '@/hooks/useRecordValidation';
 import { authFetch } from '@/lib/authFetch';
 
+/** 筋トレ 1 行のフォーム入力状態。数値項目も入力途中を扱うため文字列で保持する。 */
 type WorkoutRow = {
+  /** 行を一意に識別するキー（描画・更新・削除の対象特定に使用）。 */
   id: string;
+  /** 部位（未選択は空文字）。 */
   part: string;
+  /** 種目名。 */
   name: string;
+  /** セット数（文字列。保存時に数値へ変換）。 */
   sets: string;
+  /** 回数（文字列。保存時に数値へ変換）。 */
   reps: string;
+  /** 重量 kg（文字列。保存時に数値へ変換）。 */
   weight: string;
 };
 
+/** 有酸素 1 行のフォーム入力状態。数値項目は入力途中を扱うため文字列で保持する。 */
 type CardioRow = {
+  /** 行を一意に識別するキー。 */
   id: string;
+  /** 有酸素種別。 */
   type: 'ラン' | 'ウォーク';
+  /** 時間（分。文字列で保持し保存時に数値へ変換）。 */
   minutes: string;
+  /** 距離（km。文字列で保持し保存時に数値へ変換）。 */
   distance: string;
 };
 
+/** API から取得する既存記録の詳細。フォームへプリセットするために使用する。 */
 type RecordDetail = {
+  /** 記録日（`YYYY-MM-DD`）。 */
   date: string;
+  /** 体調メモ（未入力時は `null`）。 */
   memo: string | null;
+  /** 筋トレ項目（数値はサーバー保存値のため number）。 */
   workouts: { id: string; part: string; name: string; sets: number; reps: number; weight: number }[];
+  /** 有酸素項目（数値はサーバー保存値のため number）。 */
   cardios: { type: string; minutes: number; distance: number }[];
 };
 
+/** 記録編集ページの props。動的セグメントの日付を非同期に受け取る。 */
 type PageProps = {
+  /** URL 動的セグメント。編集対象の記録日（`YYYY-MM-DD`）を含む Promise。 */
   params: Promise<{ date: string }>;
 };
 
+/**
+ * サーバー保存済みの筋トレ項目をフォーム入力行へ変換する。数値項目は文字列へ変換する。
+ *
+ * @param workout - API から取得した筋トレ 1 件（ID を保持する）
+ * @returns フォーム編集用の筋トレ行
+ */
 const toRow = (workout: RecordDetail['workouts'][number]): WorkoutRow => ({
   id: workout.id,
   part: workout.part,
@@ -48,6 +73,11 @@ const toRow = (workout: RecordDetail['workouts'][number]): WorkoutRow => ({
   weight: String(workout.weight),
 });
 
+/**
+ * 空の筋トレ入力行を生成する。取得結果が 0 件の場合の初期 1 行や行追加に使用する。
+ *
+ * @returns 各フィールドが空で新規 ID を持つ筋トレ行
+ */
 const emptyRow = (): WorkoutRow => ({
   id: crypto.randomUUID(),
   part: '',
@@ -57,6 +87,11 @@ const emptyRow = (): WorkoutRow => ({
   weight: '',
 });
 
+/**
+ * 空の有酸素入力行を生成する。行追加に使用する（種別は「ラン」を既定とする）。
+ *
+ * @returns 数値項目が空で新規 ID を持つ有酸素行
+ */
 const createCardioRow = (): CardioRow => ({
   id: crypto.randomUUID(),
   type: 'ラン',
@@ -64,6 +99,13 @@ const createCardioRow = (): CardioRow => ({
   distance: '',
 });
 
+/**
+ * 記録編集画面。URL の日付の既存記録を取得してフォームへプリセットし、記録追加と同一構成
+ * （筋トレ・有酸素・体調メモ）で編集する。日付は変更不可。フィールド単位バリデーション（保存
+ * 押下後に表示）を経て API へ更新保存し、推定消費カロリーを画面下部に表示する。保存成功後は
+ * 管理者向け記録一覧へ遷移する。`params` は編集対象の記録日を含む動的セグメント（非同期に
+ * 解決する）。
+ */
 export default function AdminRecordEditPage({ params }: PageProps) {
   const { date } = use(params);
   const router = useRouter();

--- a/front/src/app/admin/records/new/page.tsx
+++ b/front/src/app/admin/records/new/page.tsx
@@ -12,22 +12,39 @@ import DatePicker from '@/components/DatePicker';
 import { useRecordValidation } from '@/hooks/useRecordValidation';
 import { authFetch } from '@/lib/authFetch';
 
+/** 筋トレ 1 行のフォーム入力状態。数値項目も入力途中を扱うため文字列で保持する。 */
 type WorkoutRow = {
+  /** 行を一意に識別するキー（描画・更新・削除の対象特定に使用）。 */
   id: string;
+  /** 部位（未選択は空文字）。 */
   part: string;
+  /** 種目名。 */
   name: string;
+  /** セット数（文字列。保存時に数値へ変換）。 */
   sets: string;
+  /** 回数（文字列。保存時に数値へ変換）。 */
   reps: string;
+  /** 重量 kg（文字列。保存時に数値へ変換）。 */
   weight: string;
 };
 
+/** 有酸素 1 行のフォーム入力状態。数値項目は入力途中を扱うため文字列で保持する。 */
 type CardioRow = {
+  /** 行を一意に識別するキー。 */
   id: string;
+  /** 有酸素種別。 */
   type: 'ラン' | 'ウォーク';
+  /** 時間（分。文字列で保持し保存時に数値へ変換）。 */
   minutes: string;
+  /** 距離（km。文字列で保持し保存時に数値へ変換）。 */
   distance: string;
 };
 
+/**
+ * 空の筋トレ入力行を生成する。行追加および初期表示（最少 1 行）に使用する。
+ *
+ * @returns 各フィールドが空で新規 ID を持つ筋トレ行
+ */
 const createRow = (): WorkoutRow => ({
   id: crypto.randomUUID(),
   part: '',
@@ -37,6 +54,11 @@ const createRow = (): WorkoutRow => ({
   weight: '',
 });
 
+/**
+ * 空の有酸素入力行を生成する。行追加に使用する（種別は「ラン」を既定とする）。
+ *
+ * @returns 数値項目が空で新規 ID を持つ有酸素行
+ */
 const createCardioRow = (): CardioRow => ({
   id: crypto.randomUUID(),
   type: 'ラン',
@@ -44,6 +66,11 @@ const createCardioRow = (): CardioRow => ({
   distance: '',
 });
 
+/**
+ * 記録追加画面。日付・筋トレ（最少 1 行）・有酸素（任意）・体調メモを入力し、フィールド単位の
+ * バリデーション（保存押下後に表示）を経て API へ新規保存する。推定消費カロリーを画面下部に
+ * 表示し、同日重複（409）や保存失敗は通知する。保存成功後は一覧へ遷移する。
+ */
 export default function AdminRecordNewPage() {
   const router = useRouter();
   const [date, setDate] = useState('');

--- a/front/src/app/admin/records/page.tsx
+++ b/front/src/app/admin/records/page.tsx
@@ -1,6 +1,10 @@
 import { Suspense } from 'react';
 import AdminRecordsListClient from '@/components/AdminRecordsListClient';
 
+/**
+ * 管理者向け記録一覧画面。記録の管理操作（編集・削除への導線）を提供するクライアント
+ * コンポーネント `AdminRecordsListClient` を `Suspense` 境界内で描画する。
+ */
 export default function AdminRecordsPage() {
   return (
     <Suspense>

--- a/front/src/app/api/admin/export/route.ts
+++ b/front/src/app/api/admin/export/route.ts
@@ -56,6 +56,17 @@ const buildCsv = (records: any[]) => {
   return rows.join('\n');
 };
 
+/**
+ * 指定期間の記録データを CSV または JSON で書き出す（管理者のみ）。
+ *
+ * 管理者認証必須。`from`/`to`（`YYYY-MM-DD`）で日付範囲を絞り、`format` に応じて
+ * CSV（`Content-Disposition` 付きの添付ファイル）または JSON 配列を返す。
+ * 筋トレ・有酸素は 1 レコード内で行を横並びに展開し、多い方の件数分の CSV 行を出力する。
+ * ※ Issue #20 で削除予定のエンドポイント。
+ *
+ * @param request - リクエスト。`Authorization: Bearer <token>` と、クエリ `from`・`to`（必須）・`format`（`csv`|`json`、既定 `csv`）を参照する
+ * @returns 200: CSV テキストまたは JSON 配列。401/403: 認証・認可エラー。400: `from`/`to` 欠落または `format` 不正。503: DB 接続不可
+ */
 export async function GET(request: Request) {
   const auth = await requireAdmin(request);
   if (!auth.authorized) return auth.response;

--- a/front/src/app/api/admin/me/route.ts
+++ b/front/src/app/api/admin/me/route.ts
@@ -5,6 +5,16 @@ const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '';
 const adminEmail = process.env.ADMIN_EMAIL?.trim().toLowerCase() ?? '';
 
+/**
+ * 現在のリクエストユーザーが管理者かどうかを判定する（フロントの認証状態確認用）。
+ *
+ * 認証は任意で、`Authorization: Bearer <token>` があれば Supabase で検証し、
+ * ユーザーのメールが `ADMIN_EMAIL` と一致するかを返す。トークン欠落・無効時は
+ * 401、管理者以外は 403、いずれも本文は `{ isAdmin: false }`。認証設定不備時は 500。
+ *
+ * @param request - リクエスト。`Authorization` ヘッダーの Bearer トークンを参照する（任意）
+ * @returns 200: `{ isAdmin: true }`。401: トークン欠落/無効（`{ isAdmin: false }`）。403: 管理者以外（`{ isAdmin: false }`）。500: 認証設定不備
+ */
 export async function GET(request: Request) {
   if (!supabaseUrl || !supabaseAnonKey || !adminEmail) {
     return NextResponse.json({ error: 'admin auth is not configured' }, { status: 500 });

--- a/front/src/app/api/masters/[id]/route.ts
+++ b/front/src/app/api/masters/[id]/route.ts
@@ -2,10 +2,22 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getPrisma } from '@/lib/prisma';
 import { requireAdmin } from '@/lib/adminAuth';
 
+/** マスター編集・削除ハンドラーのルートコンテキスト。`params` に対象マスターの `id` を含む。 */
 type RouteContext = {
   params: Promise<{ id: string }>;
 };
 
+/**
+ * 既存のマスター（部位・種目・有酸素種別）の名称を編集する（管理者のみ）。
+ *
+ * 管理者認証必須。パスパラメータ `id` のマスターの `name` を更新する。名称は
+ * トリム後に空でないことを要求する。対象が存在しない、または同名重複で更新に
+ * 失敗した場合は 404 を返す。
+ *
+ * @param request - リクエスト。`Authorization: Bearer <token>` と、本文の `name`（更新後の名称、必須）を参照する
+ * @param context - ルートコンテキスト。`params` から対象マスターの `id` を取り出す
+ * @returns 200: 更新後のマスター。401/403: 認証・認可エラー。400: `name` 欠落。404: 対象なしまたは重複。503: DB 接続不可
+ */
 export async function PATCH(request: NextRequest, context: RouteContext) {
   const auth = await requireAdmin(request);
   if (!auth.authorized) return auth.response;
@@ -33,6 +45,16 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
   }
 }
 
+/**
+ * 既存のマスター（部位・種目・有酸素種別）を削除する（管理者のみ）。
+ *
+ * 管理者認証必須。パスパラメータ `id` のマスターを削除する。対象が存在せず
+ * 削除に失敗した場合は 404 を返す。
+ *
+ * @param request - リクエスト。`Authorization: Bearer <token>` を参照する
+ * @param context - ルートコンテキスト。`params` から対象マスターの `id` を取り出す
+ * @returns 200: `{ ok: true }`。401/403: 認証・認可エラー。404: 対象なし。503: DB 接続不可
+ */
 export async function DELETE(request: NextRequest, context: RouteContext) {
   const auth = await requireAdmin(request);
   if (!auth.authorized) return auth.response;

--- a/front/src/app/api/masters/route.ts
+++ b/front/src/app/api/masters/route.ts
@@ -7,6 +7,15 @@ const ALLOWED_TYPES = new Set(['body-parts', 'exercises', 'cardio-types']);
 const isValidType = (value: string | null): value is string =>
   value !== null && ALLOWED_TYPES.has(value);
 
+/**
+ * 指定種別のマスター（部位・種目・有酸素種別）を名称昇順で一覧取得する。
+ *
+ * 認証不要。クエリ `type` は `body-parts` / `exercises` / `cardio-types` のいずれか
+ * である必要があり、それ以外や未指定は 400 を返す。
+ *
+ * @param request - リクエスト。クエリ `type`（取得対象の種別、必須）を参照する
+ * @returns 200: マスターの配列（名称昇順）。400: `type` 不正。503: DB 接続不可
+ */
 export async function GET(request: Request) {
   const prisma = getPrisma();
   if (!prisma) {
@@ -27,6 +36,16 @@ export async function GET(request: Request) {
   return NextResponse.json(masters);
 }
 
+/**
+ * 指定種別のマスター（部位・種目・有酸素種別）を新規追加する（管理者のみ）。
+ *
+ * 管理者認証必須。クエリ `type` は `body-parts` / `exercises` / `cardio-types` の
+ * いずれか。本文の `name` はトリム後に空でないことを要求する。同種別内で名称が
+ * 重複する場合は 409 を返す。
+ *
+ * @param request - リクエスト。`Authorization: Bearer <token>`、クエリ `type`（必須）、本文の `name`（追加する名称、必須）を参照する
+ * @returns 200: 作成したマスター。401/403: 認証・認可エラー。400: `type` 不正または `name` 欠落。409: 名称重複。503: DB 接続不可
+ */
 export async function POST(request: Request) {
   const auth = await requireAdmin(request);
   if (!auth.authorized) return auth.response;

--- a/front/src/app/api/profile/route.ts
+++ b/front/src/app/api/profile/route.ts
@@ -4,6 +4,15 @@ import { requireAdmin } from '@/lib/adminAuth';
 
 let fallbackWeightKg: number | null = null;
 
+/**
+ * 保存済みの体重（kg）を取得する。
+ *
+ * 認証不要。最新のプロフィール行から体重を返す。DB 未接続や取得失敗時は
+ * プロセス内の暫定フォールバック値（直近保存値。無ければ `null`）を返す。
+ * ※ 暫定実装のエンドポイント。
+ *
+ * @returns 200: `{ weightKg }`（未保存かつフォールバック無しは `null`）
+ */
 export async function GET() {
   const prisma = getPrisma();
   if (!prisma) {
@@ -22,6 +31,16 @@ export async function GET() {
   }
 }
 
+/**
+ * 体重（kg）を保存する（管理者のみ）。
+ *
+ * 管理者認証必須。既存プロフィール行があれば更新し、旧バグで生成された重複行を
+ * 併せて削除する。無ければ新規作成する。DB エラーは無視し、常に暫定フォールバック
+ * 値を更新して保存値を返す。※ 暫定実装のエンドポイント。
+ *
+ * @param request - リクエスト。`Authorization: Bearer <token>` と、本文の `weightKg`（数値、必須）を参照する
+ * @returns 200: `{ weightKg }`。401/403: 認証・認可エラー。400: `weightKg` が数値でない
+ */
 export async function POST(request: Request) {
   const auth = await requireAdmin(request);
   if (!auth.authorized) return auth.response;

--- a/front/src/app/api/records/[date]/route.ts
+++ b/front/src/app/api/records/[date]/route.ts
@@ -2,10 +2,21 @@ import { NextResponse } from 'next/server';
 import { getPrisma } from '@/lib/prisma';
 import { requireAdmin } from '@/lib/adminAuth';
 
+/** 記録の詳細取得・編集・削除ハンドラーのルートコンテキスト。`params` に対象日付（`YYYY-MM-DD`）を含む。 */
 type RouteContext = {
   params: Promise<{ date: string }>;
 };
 
+/**
+ * 指定日付の記録詳細（メモ・筋トレ・有酸素）を取得する。
+ *
+ * 認証不要。パスパラメータ `date` の記録を、筋トレ（`workouts`）と有酸素（`cardios`）を
+ * 含めて返す。該当日の記録が存在しない場合は 404。
+ *
+ * @param _request - リクエスト（本ハンドラーでは未使用）
+ * @param context - ルートコンテキスト。`params` から対象日付を取り出す
+ * @returns 200: `date`/`memo`/`workouts`/`cardios` を持つ詳細。404: 対象日付の記録なし。503: DB 接続不可
+ */
 export async function GET(_request: Request, context: RouteContext) {
   const prisma = getPrisma();
   if (!prisma) {
@@ -52,6 +63,17 @@ export async function GET(_request: Request, context: RouteContext) {
   });
 }
 
+/**
+ * 指定日付の記録を編集する（管理者のみ）。
+ *
+ * 管理者認証必須。既存の筋トレ・有酸素を一旦全削除し、メモを更新したうえで本文の
+ * `workouts`/`cardios` を作り直す（全置換）。対象日付の記録が無ければ 404、本文が
+ * 不正 JSON なら 400 を返す。
+ *
+ * @param request - リクエスト。`Authorization: Bearer <token>` と、本文の `memo`・`workouts`・`cardios` を参照する
+ * @param context - ルートコンテキスト。`params` から対象日付を取り出す
+ * @returns 200: `{ id }`（更新後レコード ID）。401/403: 認証・認可エラー。400: 不正な本文。404: 対象日付の記録なし。500: 更新処理エラー。503: DB 接続不可
+ */
 export async function PATCH(request: Request, context: RouteContext) {
   const auth = await requireAdmin(request);
   if (!auth.authorized) return auth.response;
@@ -126,6 +148,16 @@ export async function PATCH(request: Request, context: RouteContext) {
   }
 }
 
+/**
+ * 指定日付の記録を関連データごと削除する（管理者のみ）。
+ *
+ * 管理者認証必須。パスパラメータ `date` の記録に紐づく筋トレ・有酸素を削除してから
+ * レコード本体を削除する。対象日付の記録が無ければ 404。
+ *
+ * @param request - リクエスト。`Authorization: Bearer <token>` を参照する
+ * @param context - ルートコンテキスト。`params` から対象日付を取り出す
+ * @returns 200: `{ ok: true }`。401/403: 認証・認可エラー。404: 対象日付の記録なし。503: DB 接続不可
+ */
 export async function DELETE(request: Request, context: RouteContext) {
   const auth = await requireAdmin(request);
   if (!auth.authorized) return auth.response;

--- a/front/src/app/api/records/route.ts
+++ b/front/src/app/api/records/route.ts
@@ -4,6 +4,16 @@ import { requireAdmin } from '@/lib/adminAuth';
 
 const PAGE_LIMIT = 10;
 
+/**
+ * 記録一覧を日付降順・ページング付きで取得する。
+ *
+ * 認証不要。1 ページ 10 件固定。クエリ `page` は 1 始まりで、未指定/NaN/0 以下は 1 に
+ * 正規化し、総ページ数を超える値は最終ページに丸める。各記録は筋トレのセット数合計・
+ * 有酸素の合計時間/距離と有酸素明細を集約して返す。
+ *
+ * @param request - リクエスト。クエリ `page`（取得ページ、任意）を参照する
+ * @returns 200: `{ records, totalCount, page, totalPages }`。503: DB 接続不可
+ */
 export async function GET(request: Request) {
   const prisma = getPrisma();
   if (!prisma) {
@@ -46,6 +56,15 @@ export async function GET(request: Request) {
   return NextResponse.json({ records: result, totalCount, page, totalPages });
 }
 
+/**
+ * 1 日 1 レコードの記録を新規作成する（管理者のみ）。
+ *
+ * 管理者認証必須。本文の `date` は必須。同日既存レコードがある場合は上書きせず 409。
+ * 記録本体を作成後、本文の `workouts`/`cardios` を紐付けて作成する。
+ *
+ * @param request - リクエスト。`Authorization: Bearer <token>` と、本文の `date`（必須）・`memo`・`workouts`・`cardios` を参照する
+ * @returns 200: `{ id }`（作成レコード ID）。401/403: 認証・認可エラー。400: `date` 欠落。409: 同日重複。500: 作成処理エラー。503: DB 接続不可
+ */
 export async function POST(request: Request) {
   const auth = await requireAdmin(request);
   if (!auth.authorized) return auth.response;

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -2,11 +2,17 @@ import type { Metadata } from 'next';
 import SidebarNav from '@/components/SidebarNav';
 import './globals.css';
 
+/** アプリ全体の既定メタデータ（ブラウザタブのタイトルと説明文）。 */
 export const metadata: Metadata = {
   title: 'Exercise My Record',
   description: 'フィットネス記録の一覧・詳細・管理を行うアプリ',
 };
 
+/**
+ * アプリ全体のルートレイアウト。左サイドバー（ロゴ + ナビゲーション）と本文領域の
+ * 2 カラム構成を提供し、全ページ共通の `<html>` / `<body>` とグローバル CSS を適用する。
+ * `children` はサイドバー右側の本文領域に描画する各ページの内容。
+ */
 export default function RootLayout({
   children,
 }: Readonly<{

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -1,6 +1,11 @@
 import { Suspense } from 'react';
 import RecordsListClient from '@/components/RecordsListClient';
 
+/**
+ * トップページ（記録一覧画面）。日付降順で記録カードを表示するクライアントコンポーネント
+ * `RecordsListClient` を `Suspense` 境界内で描画する。ページングやクエリパラメータ参照に
+ * 備え Suspense でラップしている。
+ */
 export default function HomePage() {
   return (
     <Suspense>

--- a/front/src/app/records/[date]/page.tsx
+++ b/front/src/app/records/[date]/page.tsx
@@ -1,14 +1,22 @@
 import type { Metadata } from 'next';
 import RecordDetailClient from '@/components/RecordDetailClient';
 
+/** 記録詳細ページの props。動的セグメントの日付を非同期に受け取る。 */
 type PageProps = {
+  /** URL 動的セグメント。表示対象の記録日（`YYYY-MM-DD`）を含む Promise。 */
   params: Promise<{ date: string }>;
 };
 
+/** 記録詳細ページのメタデータ（ブラウザタブのタイトル）。 */
 export const metadata: Metadata = {
   title: '記録詳細',
 };
 
+/**
+ * 記録詳細画面。URL の日付セグメントを解決し、その日の記録（筋トレ・有酸素・体調メモ・
+ * 推定消費カロリー）を表示するクライアントコンポーネント `RecordDetailClient` へ日付を渡す。
+ * `params` は表示対象の記録日を含む動的セグメント（非同期に解決する）。
+ */
 export default async function RecordDetailPage({ params }: PageProps) {
   const { date } = await params;
   return <RecordDetailClient date={date} />;

--- a/front/src/components/AdminRecordsListClient.tsx
+++ b/front/src/components/AdminRecordsListClient.tsx
@@ -10,13 +10,25 @@ import { buttonClasses } from '@/components/ui/Button';
 import LoadingSpinner from '@/components/ui/LoadingSpinner';
 import { authFetch } from '@/lib/authFetch';
 
+/** 管理記録一覧の 1 日分サマリー。 */
 export type AdminRecordSummary = {
+  /** 記録日（`YYYY-MM-DD`）。一覧の一意キー兼詳細/編集への遷移パラメータ。 */
   date: string;
+  /** その日の筋トレセット数の合計。 */
   totalSets: number;
+  /** その日の有酸素運動の合計時間（分）。 */
   cardioMinutes: number;
+  /** その日の有酸素運動の合計距離（km）。 */
   cardioDistance: number;
 };
 
+/**
+ * 管理者向けの記録一覧クライアント。ページング付きで記録を表示し、削除・編集への導線を提供する。
+ *
+ * URL の `page` クエリを唯一の真実としてページ状態を同期し、削除後は現在ページを再取得する。
+ * 再取得結果が空かつ 2 ページ目以降なら前ページへ戻る。API がページ番号をクランプした場合は
+ * URL を補正する。
+ */
 export default function AdminRecordsListClient() {
   const router = useRouter();
   const searchParams = useSearchParams();

--- a/front/src/components/CalorieEstimate.tsx
+++ b/front/src/components/CalorieEstimate.tsx
@@ -8,16 +8,28 @@ import {
   type CardioType,
 } from '@/lib/calorie';
 
+/** 消費カロリー算定に用いる有酸素 1 件分の入力。 */
 type CardioEntry = {
+  /** 有酸素種別（METs 係数の決定に使う）。 */
   type: CardioType;
+  /** 運動時間（分）。 */
   minutes: number;
 };
 
+/** {@link CalorieEstimate} の props。 */
 type CalorieEstimateProps = {
+  /** その日の筋トレセット数の合計。 */
   totalSets: number;
+  /** その日の有酸素運動の一覧。 */
   cardios: CardioEntry[];
 };
 
+/**
+ * その日の記録から推定消費カロリー（目安）を表示する。
+ *
+ * プロフィール API から体重を取得し、筋トレ + 有酸素の合計を算定する。体重未取得の間は
+ * `-- kcal` を表示する。props の各項目は {@link CalorieEstimateProps} を参照。
+ */
 export default function CalorieEstimate({
   totalSets,
   cardios,

--- a/front/src/components/DatePicker.tsx
+++ b/front/src/components/DatePicker.tsx
@@ -3,10 +3,15 @@
 import { useMemo, useState } from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 
+/** {@link DatePicker} の props。 */
 type DatePickerProps = {
+  /** 現在選択中の日付（`YYYY-MM-DD` 形式。空文字は未選択）。 */
   value: string;
+  /** 日付選択時に `YYYY-MM-DD` 形式の文字列を渡すコールバック。 */
   onChange: (value: string) => void;
+  /** 未選択時に表示するプレースホルダー（既定は「日付を選択」）。 */
   placeholder?: string;
+  /** `true` で操作を無効化する。 */
   disabled?: boolean;
 };
 
@@ -14,9 +19,23 @@ const WEEK_LABELS = ['日', '月', '火', '水', '木', '金', '土'];
 
 const pad = (value: number) => String(value).padStart(2, '0');
 
+/**
+ * Date をローカルタイムゾーンの `YYYY-MM-DD` 文字列へ変換する。
+ *
+ * `toISOString()` は UTC 変換で日付がずれるため、ローカルの年月日を直接組み立てる。
+ *
+ * @param date - 変換対象の日付
+ * @returns `YYYY-MM-DD` 形式の文字列
+ */
 const toLocalIso = (date: Date) =>
   `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
 
+/**
+ * `YYYY-MM-DD` 文字列を Date へパースする。
+ *
+ * @param value - 日付文字列（空文字・不正値は `null`）
+ * @returns 解釈できた場合は Date、それ以外は `null`
+ */
 const parseDate = (value: string) => {
   if (!value) return null;
   const [year, month, day] = value.split('-').map((part) => Number(part));
@@ -26,6 +45,15 @@ const parseDate = (value: string) => {
   return parsed;
 };
 
+/**
+ * 月間カレンダーのセル配列を組み立てる。
+ *
+ * 月初の曜日に合わせて先頭を `null`（空白セル）で埋め、以降に 1〜末日を並べる。
+ *
+ * @param year - 対象の西暦年
+ * @param month - 対象の月（0 始まり。0=1月）
+ * @returns 空白は `null`、日付は数値で並ぶセル配列
+ */
 const buildCalendar = (year: number, month: number) => {
   const first = new Date(year, month, 1);
   const daysInMonth = new Date(year, month + 1, 0).getDate();
@@ -36,6 +64,13 @@ const buildCalendar = (year: number, month: number) => {
   return cells;
 };
 
+/**
+ * 年ジャンプ対応の月間カレンダー型日付ピッカー。
+ *
+ * ボタン押下でカレンダーを開閉し、年・月をセレクトで切り替えて日付を選択する。選択結果は
+ * `YYYY-MM-DD`（ローカルタイム基準）で `onChange` に渡す。props の各項目は
+ * {@link DatePickerProps} を参照。
+ */
 export default function DatePicker({
   value,
   onChange,

--- a/front/src/components/RecordDetailClient.tsx
+++ b/front/src/components/RecordDetailClient.tsx
@@ -9,30 +9,53 @@ import LoadingSpinner from '@/components/ui/LoadingSpinner';
 import CalorieEstimate from '@/components/CalorieEstimate';
 import { useAdminSession } from '@/hooks/useAdminSession';
 
+/** 記録詳細における筋トレ 1 種目分のデータ。 */
 export type DetailWorkout = {
+  /** 種目の一意 ID（リストの key に使用）。 */
   id: string;
+  /** 種目名。 */
   name: string;
+  /** 対象部位。 */
   part: string;
+  /** セット数。 */
   sets: number;
+  /** 1 セットあたりの回数。 */
   reps: number;
+  /** 重量（kg）。 */
   weight: number;
 };
 
+/** 記録詳細における有酸素 1 件分のデータ。 */
 type CardioDetail = { type: string; minutes: number; distance: number };
 
+/** 記録詳細 API から取得する 1 日分のレスポンス形。 */
 type RecordDetailData = {
+  /** 記録日（`YYYY-MM-DD`）。 */
   date: string;
+  /** 体調メモ。未入力時は `null`。 */
   memo: string | null;
+  /** 筋トレ種目の一覧。 */
   workouts: DetailWorkout[];
+  /** 有酸素運動の一覧。 */
   cardios: CardioDetail[];
 };
 
+/** {@link RecordDetailClient} の props。 */
 type RecordDetailClientProps = {
+  /** 表示対象の記録日（`YYYY-MM-DD`）。 */
   date: string;
 };
 
+/** 再レンダーごとの参照変化を避けるための空配列（`useMemo` 依存の安定化用）。 */
 const EMPTY_WORKOUTS: DetailWorkout[] = [];
 
+/**
+ * 指定日の記録詳細を表示するクライアント。筋トレ・有酸素・メモ・推定カロリーを一覧化する。
+ *
+ * マウント時と `date` 変更時に詳細 API を取得し、404 は「見つからない」、その他失敗は
+ * 「取得失敗」を表示する。管理者（{@link useAdminSession}）にのみ編集リンクを出す。props の
+ * 各項目は {@link RecordDetailClientProps} を参照。
+ */
 export default function RecordDetailClient({ date }: RecordDetailClientProps) {
   const [detail, setDetail] = useState<RecordDetailData | null>(null);
   const [errorMessage, setErrorMessage] = useState('');

--- a/front/src/components/RecordsListClient.tsx
+++ b/front/src/components/RecordsListClient.tsx
@@ -11,16 +11,30 @@ import LoadingSpinner from '@/components/ui/LoadingSpinner';
 import CalorieEstimate from '@/components/CalorieEstimate';
 import { useAdminSession } from '@/hooks/useAdminSession';
 
+/** 一覧サマリーに含める有酸素 1 件分のデータ（推定カロリー算定にも使う）。 */
 type CardioSummary = { type: string; minutes: number; distance: number };
 
+/** 記録一覧の 1 日分サマリー。 */
 export type RecordSummary = {
+  /** 記録日（`YYYY-MM-DD`）。一覧の一意キー兼詳細への遷移パラメータ。 */
   date: string;
+  /** その日の筋トレセット数の合計。 */
   totalSets: number;
+  /** その日の有酸素運動の合計時間（分）。 */
   cardioMinutes: number;
+  /** その日の有酸素運動の合計距離（km）。 */
   cardioDistance: number;
+  /** その日の有酸素運動の一覧（推定カロリー表示に使用）。 */
   cardios: CardioSummary[];
 };
 
+/**
+ * 一般ユーザー向けの記録一覧クライアント。ページング付きで記録と推定カロリーを表示する。
+ *
+ * URL の `page` クエリを唯一の真実としてページ状態を同期し、API がページ番号をクランプした
+ * 場合は URL を補正する。管理者（{@link useAdminSession}）には管理者メニューと記録追加への
+ * 導線を追加表示する。
+ */
 export default function RecordsListClient() {
   const router = useRouter();
   const searchParams = useSearchParams();

--- a/front/src/components/SidebarNav.tsx
+++ b/front/src/components/SidebarNav.tsx
@@ -3,6 +3,12 @@
 import { History, LayoutGrid } from 'lucide-react';
 import { useAdminSession } from '@/hooks/useAdminSession';
 
+/**
+ * サイドバーのナビゲーション。記録一覧への導線に加え、管理者にのみ管理者メニューを表示する。
+ *
+ * 管理者判定は {@link useAdminSession} に依存し、判定中（`isLoading`）は管理者リンクを出さない。
+ * バイパス経由（`isBypass`）でも管理者リンクを表示する。
+ */
 export default function SidebarNav() {
   const { isAdmin, isLoading, isBypass } = useAdminSession();
 

--- a/front/src/components/ui/Button.tsx
+++ b/front/src/components/ui/Button.tsx
@@ -1,5 +1,6 @@
 import type { ButtonHTMLAttributes } from 'react';
 
+/** ボタンの見た目バリアント。primary=主要操作 / outline=枠線 / pink=強調追加 / danger=削除系。 */
 export type ButtonVariant = 'primary' | 'outline' | 'pink' | 'danger';
 
 const base = 'rounded-full px-4 py-2 text-sm font-bold transition inline-flex items-center gap-2';
@@ -11,13 +12,29 @@ const variants: Record<ButtonVariant, string> = {
   danger: 'border border-[#a94040] text-[#a94040] hover:bg-[#a94040] hover:text-white',
 };
 
+/**
+ * バリアントに対応した Tailwind クラス文字列を組み立てる。
+ *
+ * `<Button>` を使わず `<Link>` や素の要素へ同じ見た目を当てたいときに利用する。
+ *
+ * @param variant - 適用する見た目バリアント（既定は `primary`）
+ * @returns 共通クラスとバリアント別クラスを連結した文字列
+ */
 export const buttonClasses = (variant: ButtonVariant = 'primary') =>
   `${base} ${variants[variant]}`;
 
+/** {@link Button} の props。標準の button 属性に見た目バリアントを加えたもの。 */
 type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  /** 適用する見た目バリアント（既定は `primary`）。 */
   variant?: ButtonVariant;
 };
 
+/**
+ * 共通スタイルを当てた汎用ボタン。バリアントと任意の追加クラスを合成する。
+ *
+ * props は button 標準属性に加え {@link ButtonProps} の `variant` を受け取る
+ * （`className` は共通スタイルへ追記される）。
+ */
 export default function Button({ className = '', variant = 'primary', ...props }: ButtonProps) {
   return <button className={`${buttonClasses(variant)} ${className}`} {...props} />;
 }

--- a/front/src/components/ui/Card.tsx
+++ b/front/src/components/ui/Card.tsx
@@ -1,5 +1,10 @@
 import type { HTMLAttributes } from 'react';
 
+/**
+ * カード外観（角丸・影）の共通ラッパー div。任意の追加クラスを合成する。
+ *
+ * props は div 標準属性を受け取り、`className` は共通スタイルへ追記される。
+ */
 export default function Card({ className = '', ...props }: HTMLAttributes<HTMLDivElement>) {
   return <div className={`af-card soft-shadow ${className}`} {...props} />;
 }

--- a/front/src/components/ui/LoadingSpinner.tsx
+++ b/front/src/components/ui/LoadingSpinner.tsx
@@ -1,12 +1,19 @@
 import { LoaderCircle } from 'lucide-react';
 
+/** 処理種別。既定ラベルと文字色を切り替えるためのキー。 */
 type LoadingMode = 'fetching' | 'saving' | 'deleting' | 'exporting' | 'auth';
+/** 表示形態。block=独立ブロック / inline=行内（ボタン内など）。 */
 type LoadingVariant = 'block' | 'inline';
 
+/** {@link LoadingSpinner} の props。 */
 type LoadingSpinnerProps = {
+  /** 処理種別。既定ラベル・色を決める（既定は `fetching`）。 */
   mode?: LoadingMode;
+  /** 表示テキストの明示指定。指定時は `mode` の既定ラベルより優先される。 */
   label?: string;
+  /** 表示形態。アイコンサイズと外枠スタイルを決める（既定は `block`）。 */
   variant?: LoadingVariant;
+  /** 追加の Tailwind クラス。 */
   className?: string;
 };
 
@@ -31,6 +38,12 @@ const variantClasses: Record<LoadingVariant, string> = {
   inline: 'inline-flex items-center gap-2 text-sm font-bold',
 };
 
+/**
+ * 回転アイコン付きのローディング表示。処理種別ごとに色とラベルを変える。
+ *
+ * `role="status"` / `aria-live="polite"` を付与し、状態変化をスクリーンリーダーへ通知する。
+ * props の各項目は {@link LoadingSpinnerProps} を参照。
+ */
 export default function LoadingSpinner({
   mode = 'fetching',
   label,

--- a/front/src/components/ui/PageHeader.tsx
+++ b/front/src/components/ui/PageHeader.tsx
@@ -6,13 +6,22 @@ const widthMap = {
   '5xl': 'max-w-5xl',
 };
 
+/** {@link PageHeader} の props。 */
 type PageHeaderProps = {
+  /** 見出し（大きく表示するページタイトル）。 */
   title: string;
+  /** 小さく上部に表示する補助ラベル（英語表記など）。省略時は非表示。 */
   subtitle?: string;
+  /** 右側に配置するアクション要素（ボタンやリンク）。 */
   action?: ReactNode;
+  /** 中央寄せコンテンツの最大幅キー（既定は `5xl`）。 */
   maxWidth?: keyof typeof widthMap;
 };
 
+/**
+ * ページ上部に固定表示するヘッダー。タイトル・補助ラベル・右側アクションを配置する。
+ * props の各項目は {@link PageHeaderProps} を参照。
+ */
 export default function PageHeader({
   title,
   subtitle,

--- a/front/src/hooks/useAdminSession.ts
+++ b/front/src/hooks/useAdminSession.ts
@@ -12,13 +12,28 @@ type AdminSessionState = {
   isBypass: boolean;
 };
 
+/** E2E 用の認証バイパスを許可するか。非本番環境でのみ `true`（本番は常に無効）。 */
 export const isBypassAllowed = process.env.NODE_ENV !== 'production';
 
+/**
+ * localStorage に保存された E2E バイパスフラグの有無を返す。
+ *
+ * バイパス非許可環境（本番）・サーバー側（`window` 不在）では常に `false`。
+ *
+ * @returns バイパスが有効なら `true`
+ */
 export function getBypassFlag() {
   if (!isBypassAllowed || typeof window === 'undefined') return false;
   return localStorage.getItem(BYPASS_KEY) === '1';
 }
 
+/**
+ * E2E バイパスフラグを localStorage に設定・解除する。
+ *
+ * バイパス非許可環境（本番）では何もしない。
+ *
+ * @param enabled - `true` でバイパスを有効化、`false` で解除
+ */
 export function setBypassSession(enabled: boolean) {
   if (!isBypassAllowed) return;
   if (enabled) {
@@ -28,6 +43,15 @@ export function setBypassSession(enabled: boolean) {
   }
 }
 
+/**
+ * 管理者ログイン状態を購読するフック。
+ *
+ * Supabase セッションを監視し、`/api/admin/me` で管理者判定を行う。非本番では localStorage の
+ * E2E バイパスフラグも加味する。認証状態の変化（ログイン/ログアウト）に追従し、古い非同期結果で
+ * 状態を上書きしないよう最新リクエストのみ反映する。
+ *
+ * @returns `isAdmin`（管理者か）/ `isLoading`（判定中か）/ `isBypass`（バイパス経由の管理者か）
+ */
 export function useAdminSession(): AdminSessionState {
   const [sessionActive, setSessionActive] = useState(false);
   const [bypassActive, setBypassActive] = useState(() => getBypassFlag());

--- a/front/src/hooks/useRecordValidation.ts
+++ b/front/src/hooks/useRecordValidation.ts
@@ -11,6 +11,18 @@ export type { WorkoutRow, CardioRow, ValidationErrors };
 
 const EMPTY_ERRORS: ValidationErrors = { workouts: {}, cardios: {} };
 
+/**
+ * 記録フォームのバリデーション状態を管理するフック。
+ *
+ * 入力値から常にエラーを再計算しつつ、表示は「保存押下後（`submitted`）」まで抑制する。
+ * これにより初期表示ではエラーを出さず、保存を試みてから初めてフィールド下に表示する挙動を実現する。
+ *
+ * @param date - 日付入力
+ * @param workouts - 筋トレ行の配列
+ * @param cardios - 有酸素行の配列
+ * @returns `rawErrors`（常時計算した実エラー）/ `displayErrors`（表示用・未送信なら空）/
+ *   `hasErrors`（保存可否）/ `submitted` と `setSubmitted`（送信済みフラグの制御）
+ */
 export function useRecordValidation(
   date: string,
   workouts: WorkoutRow[],

--- a/front/src/lib/adminAuth.ts
+++ b/front/src/lib/adminAuth.ts
@@ -9,10 +9,22 @@ const isE2eBypass =
   process.env.NODE_ENV !== 'production' &&
   process.env.E2E_BYPASS === '1';
 
+/** 管理者認証の結果。未認可時は呼び出し側がそのまま返せる `response` を同梱する。 */
 type AuthResult =
   | { authorized: true }
   | { authorized: false; response: NextResponse };
 
+/**
+ * 書き込み系 API の管理者認証ガード（防御の第 1 層）。
+ *
+ * `Authorization: Bearer <token>` を Supabase で検証し、ユーザーのメールが `ADMIN_EMAIL`
+ * と一致する場合のみ認可する。非本番かつ `E2E_BYPASS=1` のときは検証を丸ごとバイパスする。
+ * 未認可時はステータス付きの `NextResponse`（401=トークン無効/欠落・403=管理者以外・
+ * 500=認証設定不備）を `response` に格納して返す。
+ *
+ * @param request - 検証対象のリクエスト（`Authorization` ヘッダーを参照）
+ * @returns 認可可否。`authorized: false` の場合は返却用の `response` を含む
+ */
 export async function requireAdmin(request: Request): Promise<AuthResult> {
   if (isE2eBypass) {
     return { authorized: true };

--- a/front/src/lib/authFetch.ts
+++ b/front/src/lib/authFetch.ts
@@ -1,5 +1,15 @@
 import { supabase } from '@/lib/supabase';
 
+/**
+ * Supabase セッションの access token を `Authorization: Bearer` として自動付与する `fetch` ラッパー。
+ *
+ * 書き込み系 API 呼び出しで使用する。セッションが無い場合はヘッダーを付けずに素の `fetch` を行う
+ * （その場合サーバー側で 401 となる）。
+ *
+ * @param url - リクエスト先 URL
+ * @param options - `fetch` に渡すオプション。既存の `headers` は保持したうえで認証ヘッダーを追加する
+ * @returns `fetch` のレスポンス
+ */
 export async function authFetch(
   url: string,
   options: RequestInit = {},

--- a/front/src/lib/calorie.ts
+++ b/front/src/lib/calorie.ts
@@ -1,5 +1,12 @@
+/** 有酸素種別の識別子。日本語表記・英小文字・英表記の別名を許容する。 */
 export type CardioType = 'ラン' | 'ウォーク' | 'run' | 'walk' | 'Running' | 'Walking';
 
+/**
+ * 有酸素種別ごとの METs（運動強度）係数の暫定値。
+ *
+ * ラン = 8.0 / ウォーク = 4.0。表記ゆれ（日本語・英語）を同じ係数へ寄せる。
+ * 未知の種別は係数を持たず、カロリー算定では 0 として扱う。
+ */
 export const cardioMets: Record<string, number> = {
   ラン: 8.0,
   ウォーク: 4.0,
@@ -9,6 +16,16 @@ export const cardioMets: Record<string, number> = {
   Walking: 4.0,
 };
 
+/**
+ * 有酸素運動の推定消費カロリー（目安）を時間ベースで算定する。
+ *
+ * 計算式は `METs × 体重(kg) × 時間(時間)`。未知の種別は METs=0 のためカロリー 0 を返す。
+ *
+ * @param weightKg - プロフィールに保存した体重（kg）
+ * @param minutes - 運動時間（分）。内部で時間へ換算する
+ * @param type - 有酸素種別。`cardioMets` に無い値は消費カロリー 0 とみなす
+ * @returns 推定消費カロリー（kcal、丸め前の実数）
+ */
 export const calculateCardioCalories = (
   weightKg: number,
   minutes: number,
@@ -19,7 +36,22 @@ export const calculateCardioCalories = (
   return mets * weightKg * hours;
 };
 
+/**
+ * 筋トレの推定消費カロリー（目安）をその日のセット数合計から概算する。
+ *
+ * 計算式は `体重(kg) × 0.1 × セット数合計`。
+ *
+ * @param weightKg - プロフィールに保存した体重（kg）
+ * @param totalSets - その日の筋トレセット数の合計
+ * @returns 推定消費カロリー（kcal、丸め前の実数）
+ */
 export const calculateStrengthCalories = (weightKg: number, totalSets: number) =>
   weightKg * 0.1 * totalSets;
 
+/**
+ * カロリー値を表示用に整数へ丸め、「N kcal」形式の文字列へ整形する。
+ *
+ * @param value - 丸め前の推定消費カロリー（kcal）
+ * @returns 「N kcal」形式の表示文字列
+ */
 export const formatCalories = (value: number) => `${Math.round(value)} kcal`;

--- a/front/src/lib/prisma.ts
+++ b/front/src/lib/prisma.ts
@@ -6,6 +6,15 @@ const globalForPrisma = globalThis as unknown as {
   prisma?: PrismaClient | null;
 };
 
+/**
+ * Prisma クライアント（`adapter-pg` 経由）を遅延生成し、グローバルにキャッシュして返す。
+ *
+ * `DATABASE_URL` 未設定時や初期化失敗時は `null` を返す（呼び出し側は 503 を返す想定）。
+ * 一度確定した結果（クライアント or `null`）はグローバルに保持し、開発時の HMR による
+ * 接続増殖を防ぐ。
+ *
+ * @returns Prisma クライアント。DB が利用不可なら `null`
+ */
 export function getPrisma() {
   if (globalForPrisma.prisma !== undefined) {
     return globalForPrisma.prisma;

--- a/front/src/lib/supabase.ts
+++ b/front/src/lib/supabase.ts
@@ -3,4 +3,10 @@ import { createClient } from '@supabase/supabase-js';
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '';
 
+/**
+ * ブラウザ・クライアント側で共有する Supabase クライアント（匿名キーで初期化）。
+ *
+ * 認証（Google OAuth のセッション取得・監視）に用いる。URL / 匿名キーは公開用の
+ * `NEXT_PUBLIC_*` 環境変数から読み込む。
+ */
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/front/src/lib/validation.ts
+++ b/front/src/lib/validation.ts
@@ -1,3 +1,4 @@
+/** 記録フォームの筋トレ 1 行分の入力値。数値項目もフォーム都合で文字列で保持する。 */
 export type WorkoutRow = {
   id: string;
   part: string;
@@ -7,6 +8,7 @@ export type WorkoutRow = {
   weight: string;
 };
 
+/** 記録フォームの有酸素 1 行分の入力値。数値項目もフォーム都合で文字列で保持する。 */
 export type CardioRow = {
   id: string;
   type: string;
@@ -14,14 +16,22 @@ export type CardioRow = {
   distance: string;
 };
 
+/** 1 行内のフィールド名 → エラーメッセージの対応。エラーのないフィールドはキーを持たない。 */
 type FieldErrors = Record<string, string>;
 
+/** フォーム全体のバリデーション結果。行エラーは行 id をキーに保持する。 */
 export type ValidationErrors = {
   date?: string;
   workouts: Record<string, FieldErrors>;
   cardios: Record<string, FieldErrors>;
 };
 
+/**
+ * 0 以上の数値入力を検証する（重量など 0 を許容する項目向け）。
+ *
+ * @param value - 入力値の文字列。空文字は未入力扱い
+ * @returns エラーメッセージ。妥当な場合は `undefined`
+ */
 export function validateNumericField(value: string): string | undefined {
   if (value === '') return '値を入力してください';
   const num = Number(value);
@@ -29,6 +39,12 @@ export function validateNumericField(value: string): string | undefined {
   return undefined;
 }
 
+/**
+ * 正の数値入力を検証する（セット数・回数・時間・距離など 0 を許容しない項目向け）。
+ *
+ * @param value - 入力値の文字列。空文字は未入力扱い
+ * @returns エラーメッセージ。妥当な場合は `undefined`
+ */
 export function validatePositiveNumericField(value: string): string | undefined {
   if (value === '') return '値を入力してください';
   const num = Number(value);
@@ -36,6 +52,16 @@ export function validatePositiveNumericField(value: string): string | undefined 
   return undefined;
 }
 
+/**
+ * 記録フォーム全体を検証し、フィールド単位のエラー集合を組み立てる。
+ *
+ * 有酸素行は時間・距離がともに空なら未入力の任意行として検証をスキップする。
+ *
+ * @param date - 日付入力（空なら必須エラー）
+ * @param workouts - 筋トレ行の配列（各行の部位・種目・セット・回数・重量を検証）
+ * @param cardios - 有酸素行の配列（入力のある行のみ時間・距離を検証）
+ * @returns フィールド単位のエラー。行エラーは行 id をキーに格納する
+ */
 export function computeErrors(
   date: string,
   workouts: WorkoutRow[],
@@ -78,6 +104,12 @@ export function computeErrors(
   return errors;
 }
 
+/**
+ * バリデーション結果にエラーが 1 件でも含まれるかを判定する（保存抑止の判断に使う）。
+ *
+ * @param errors - `computeErrors` の結果
+ * @returns 日付・筋トレ・有酸素のいずれかにエラーがあれば `true`
+ */
 export function hasAnyErrors(errors: ValidationErrors): boolean {
   if (errors.date) return true;
   if (Object.keys(errors.workouts).length > 0) return true;


### PR DESCRIPTION
## 概要

`youtube-my-collection` を参考に、フロントの ESLint へ **JSDoc（TSDoc スタイル）ルールを導入**し、あわせて `src/**` の**公開シンボルへ JSDoc を補強**しました（従来 JSDoc は 0 件）。

## 変更点

### ① ESLint への JSDoc 導入
- `eslint-plugin-jsdoc` を devDependency に追加
- `front/eslint.config.mjs` に JSDoc ルールブロックを追加
  - error: `no-types` / `require-param` + `require-param-description` / `check-param-names` / `require-returns` + `require-returns-description`
  - warn: `check-alignment` / `no-multi-asterisks`
  - `.tsx`（JSX 返却コンポーネント）は `@returns` を除外
  - `require-jsdoc` は未採用（既存関数への JSDoc 強制はしない）
- Prisma 自動生成コード `src/generated/**` を ESLint ignore に追加（生成物の誤検知を除去）

### ② 公開シンボルへの JSDoc 付与（全 38 ファイル）
- `src/lib/**`（6）/ `src/hooks/**`（2）/ `src/components/**`＋`ui/**`（10）/ `src/app/api/**`（7）/ `src/app/**` page・layout（13）
- 日本語・意図/挙動重視・型は書かない・`@param name - 説明`・分割代入 props は props 型側に説明を寄せ `{@link}` 参照
- 内容は `docs/03`（画面仕様）・`docs/07`（API 仕様）と整合

### ③ ドキュメント同期
- `.claude/rules/jsdoc.md` の「Lint による強制」節を実導入内容へ更新

## 確認してほしい点

- JSDoc ルールセット（`.tsx` の `@returns` 除外・`require-jsdoc` 未採用）の方針が妥当か
- 主要ファイルの JSDoc が実挙動・仕様と齟齬ないか（特に `lib/adminAuth.ts`・`app/api/records/route.ts` のステータスコード記述）
- `src/generated/**` を ESLint 対象外にした判断（`.gitignore` 済みのビルド成果物）

## 検証

- `pnpm lint`: **JSDoc 指摘 0 件**
- `tsc --noEmit`: 型エラー 0 件
- 差分はコメント追加と lint 設定のみで**ロジック変更なし**（+770 / -2）

## 補足（この PR のスコープ外）

`pnpm lint` は既存の 6 件（`@next/next/no-html-link-for-pages`×1・`@typescript-eslint/no-explicit-any`×3・`react-hooks/set-state-in-effect`×2）で exit 1 のままです。いずれも JSDoc とは無関係の既存問題のため本 PR では未対応。別途対応するかは要相談。

## ドキュメント影響

ルール（`.claude/rules/jsdoc.md`）の内容更新は本 PR に含む。README / docs の他ファイルへの影響はなし（開発コマンド `pnpm lint` は不変）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)