### PR TITLE
fix(rules): frontend.md の globs に stores/contexts/providers/constants を追加する

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -1,6 +1,6 @@
 ---
 description: Next.js (App Router) フロントエンド設計・コンポーネント規約
-globs: "front/src/components/**,front/src/app/**,front/src/hooks/**,front/src/lib/**"
+globs: "front/src/components/**,front/src/app/**,front/src/hooks/**,front/src/stores/**,front/src/contexts/**,front/src/providers/**,front/src/constants/**,front/src/lib/**"
 ---
 
 # フロントエンドルール（Next.js App Router）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,6 @@
 | github-actions.md | `.github/workflows/**` | Actions 発火ルール（関係あるジョブだけ動かす・必須チェックと `paths-ignore` を併用しない） |
 | jsdoc.md | `front/src/**` | JSDoc（TSDoc）規約・公開シンボル/型メンバー/状態・ロジック層への必須付与 |
 | typescript.md | `front/src/**` | TypeScript 固有規約（type/interface の使い分け・型/定数の配置・any禁止・enum回避・`import type`） |
-| frontend.md | `front/src/{components,app,hooks,lib}/**` | Next.js App Router フロント設計・server/client 分離・レイヤ一方向依存・型の扱い |
+| frontend.md | `front/src/{components,app,hooks,stores,contexts,providers,constants,lib}/**` | Next.js App Router フロント設計・server/client 分離・レイヤ一方向依存・型の扱い |
 | api.md | `front/src/app/api/**` | Next.js Route Handlers（一体型 API）設計・認証・エラー方針・レスポンス整形 |
 | database.md | `front/prisma/**`, `front/src/lib/**` | Prisma 命名規約・手動マイグレーション・クエリ規約・論理削除方針 |


### PR DESCRIPTION
## 概要

`.claude/rules/frontend.md` の `globs` が、rules-update テンプレートの現行値より狭かったため揃える。

Closes #92

## 変更内容

```diff
- globs: front/src/{components,app,hooks,lib}/**
+ globs: front/src/{components,app,hooks,stores,contexts,providers,constants,lib}/**
```

my-custom-skills の **PR #55 / #56** で追加された `stores/` `contexts/` `providers/` `constants/` が漏れていた。#86 で「既存ルールは保持し不足節のみ追記」する方針を採った際に、**本文はマージしたが frontmatter の `globs` を更新し忘れた**もの。

`CLAUDE.md` の Rules テーブルのスコープ列も同期した。

## なぜ対応が必要か

PR #55 の本文が指摘しているとおり、**「ルールを足しても対象ファイルに届かない」**状態になる。

該当ディレクトリは現時点で未作成のため実害はない。ただし `constants/` は `typescript.md`「定数の配置」が「2 箇所目の参照が発生した時点で昇格させる」と指示している**作られる前提のディレクトリ**であり、作った瞬間にルールの適用外になる。ディレクトリが生まれてから気づくのでは遅いので先に直す。

## 動作確認

- `npx markdownlint-cli2@0.23.1` → `0 issues in 0 files`
- ルールのドキュメントのみの変更のため、`ci.yml` はスキップされ `docs.yml` のみ起動する想定（新しい発火ルールの実地確認も兼ねる）

## 補足

本 PR はルールの取りこぼし修正のみ。**コード側のルール違反**は別途 issue 化している（親 issue #98 を参照）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)