### PR TITLE
feat(lint): 型宣言への JSDoc を ESLint で強制する

### DIFF
--- a/.claude/rules/jsdoc.md
+++ b/.claude/rules/jsdoc.md
@@ -130,5 +130,27 @@ export async function resolveDisplayName(
 - `jsdoc/require-param` / `require-param-description` / `check-param-names`（error）— JSDoc ブロックを持つ関数は全引数を `@param` で説明し、名前・順序・過不足を突き合わせる（分割代入 props は展開しない）。
 - `jsdoc/require-returns` / `require-returns-description`（error）— 戻り値がある関数は `@returns` に意味を書く。**JSX を返す `.tsx` コンポーネントは除外**（`@returns …の要素` はノイズのため）。
 - `jsdoc/check-alignment` / `no-multi-asterisks`（warn）— 体裁を整える。
+- `jsdoc/require-jsdoc`（error・`contexts` 限定）— 型宣言に JSDoc を必須にする（次節）。
 
-`require-jsdoc` は行コメントを誤検知するため未採用（JSDoc ブロックの有無・質はレビューで確認する）。Prisma 自動生成コード（`src/generated/**`）は lint 対象外。
+対象は `src/**` と `tests/**` の両方（テストを `tests/` へ集約した際に対象から漏れないようにするため。`testing.md`「ESLint の対象範囲」）。
+
+### 型宣言・型メンバーの強制
+
+型定義の検出は `jsdoc/require-jsdoc` の `contexts` に AST セレクタを指定して行う（型本体 = `TSTypeAliasDeclaration` / `TSInterfaceDeclaration`、メンバー = `TSPropertySignature`）。`require: {}` を併記して**関数・クラス等の既定対象は要求しない**。
+
+**関数に対する `require-jsdoc` は引き続き未採用**（行コメントを誤検知するため）。関数の JSDoc ブロックの有無・質はレビューで確認する。上記は型宣言のみを対象にした別用途であり、この判断とは衝突しない。
+
+適用範囲は検出件数の実測に基づいて段階的に決める。
+
+| 対象 | 粒度 | 設定 |
+|---|---|---|
+| `src/**` + `tests/**` | 型本体のみ | **error** |
+| `src/types/**` | 型本体 **+ メンバー** | **error** |
+| 上記以外でのメンバー単位 | — | **未適用** |
+
+- **メンバー単位を全体に広げない**。全体に適用すると 100 件超を検出し、「書くことがない項目に埋め草コメントを付けない」方針と衝突する。`types/` は複数箇所から参照される共有型の置き場であり、**定義ファイルを開かずに使われる**ためコメントの価値が最も高い。
+- **`warn` で導入しない。** `static-analysis.md`「警告ゼロを維持し、守れないルールは有効にしない（`error` にするか、無効にするかの二択）」に従い、**`error` にできる範囲だけを対象にする**。
+- 範囲を広げるときは、**先に検出件数を計測し、`error` にできる状態にしてから**有効化する。
+- store・フック戻り値も、「戻り値の型を先に定義する」に従えば `TSPropertySignature` として同じルールで検出できる。**オブジェクトリテラルのプロパティを直接 Lint で強制しようとしない**（宣言ではないため誤検知が多く、実効性が低い）。型定義へ寄せることで強制力を得るのが本方針の要。
+
+Prisma 自動生成コード（`src/generated/**`）は lint 対象外。

--- a/front/eslint.config.mjs
+++ b/front/eslint.config.mjs
@@ -31,7 +31,36 @@ const eslintConfig = defineConfig([
       // 書いた JSDoc の体裁を整える。
       "jsdoc/check-alignment": "warn",
       "jsdoc/no-multi-asterisks": "warn",
-      // require-jsdoc は // 行コメントを誤検知するため未採用。ブロックの有無・質はレビューで確認する。
+      // 型本体（type / interface の宣言）に JSDoc を必須にする。
+      // require: {} で関数・クラス等の既定対象は要求せず、contexts で型宣言だけを対象にする。
+      // 関数に対する require-jsdoc は // 行コメントを誤検知するため引き続き未採用で、
+      // 関数の JSDoc ブロックの有無・質はレビューで確認する。
+      "jsdoc/require-jsdoc": [
+        "error",
+        { require: {}, contexts: ["TSTypeAliasDeclaration", "TSInterfaceDeclaration"] },
+      ],
+    },
+  },
+  {
+    // 型メンバー（TSPropertySignature）単位の強制は types/ に限定する。
+    // 全体に広げると 100 件超を検出し、「書くことがない項目に埋め草コメントを付けない」
+    // 方針（jsdoc.md）と衝突する。types/ は複数箇所から参照される共有型の置き場であり、
+    // 定義ファイルを開かずに使われるためコメントの価値が最も高い。
+    // static-analysis.md「警告ゼロを維持し、守れないルールは有効にしない」に従い、
+    // warn で放置せず error にできる範囲だけを対象にしている（現状 0 件）。
+    files: ["src/types/**/*.ts"],
+    rules: {
+      "jsdoc/require-jsdoc": [
+        "error",
+        {
+          require: {},
+          contexts: [
+            "TSTypeAliasDeclaration",
+            "TSInterfaceDeclaration",
+            "TSPropertySignature",
+          ],
+        },
+      ],
     },
   },
   {

--- a/front/src/hooks/useAdminSession.ts
+++ b/front/src/hooks/useAdminSession.ts
@@ -6,9 +6,16 @@ import { supabase } from '@/lib/supabase';
 
 const BYPASS_KEY = 'e2e_admin_bypass';
 
+/**
+ * 管理者セッションの判定結果。判定中と「判定済みで非管理者」を区別するため、
+ * `isAdmin` と `isLoading` を独立させている。
+ */
 type AdminSessionState = {
+  /** 管理者として認証済みか。`isLoading` が true の間は常に false（未確定を意味しない） */
   isAdmin: boolean;
+  /** セッション判定中か。true の間は `isAdmin` の値で画面を分岐させない */
   isLoading: boolean;
+  /** E2E バイパスによる管理者扱いか。本番では常に false（`isBypassAllowed` 参照） */
   isBypass: boolean;
 };
 

--- a/front/tests/setup/it-global-setup.ts
+++ b/front/tests/setup/it-global-setup.ts
@@ -3,6 +3,10 @@ import { PostgreSqlContainer } from '@testcontainers/postgresql';
 
 // IT で provide/inject する値の型を宣言する。
 declare module 'vitest' {
+  /**
+   * グローバルセットアップから各テストへ `provide`/`inject` で渡す値。
+   * vitest 側の型を宣言マージで拡張するため `interface` を使う（`typescript.md` 条件 2）。
+   */
   export interface ProvidedContext {
     /** Testcontainers で起動した PostgreSQL への接続文字列。 */
     DATABASE_URL: string;

--- a/front/tests/unit/app/api/admin/export/route.test.ts
+++ b/front/tests/unit/app/api/admin/export/route.test.ts
@@ -13,7 +13,12 @@ vi.mock('@/lib/adminAuth', () => ({
 import { getPrisma } from '@/lib/prisma';
 import { requireAdmin } from '@/lib/adminAuth';
 
+/**
+ * データ出力 API のテストが Prisma のモックに返させる 1 レコード分の形。
+ * 実 Prisma の戻り値のうち、CSV / JSON 生成が参照する項目だけを持つ部分実装。
+ */
 type ExportRecord = {
+  /** 記録日。CSV では `YYYY-MM-DD` へ整形される */
   date: Date;
   memo: string | null;
   workouts: { part: string; name: string; sets: number; reps: number; weight: number }[];


### PR DESCRIPTION
## 概要

#86 で `jsdoc.md` に「**型定義のコメント（型本体＋各メンバー）**」を追加したが、**それを Lint で強制する手段の記述が落ちており**、レビュー頼みになっていた。`static-analysis.md` は「機械判定できるものは CI で強制する」方針なので、その片手落ちを解消する。

Closes #100

## 導入範囲は実測で決めた

いきなり全体に適用すると埋め草コメントを誘発するため、粒度と対象を変えて検出件数を計測した。

| 設定 | 検出件数 |
|---|---|
| **型本体のみ** × `src` + `tests` | **3 件** |
| メンバー含む × `src` + `tests` | **104 件** |
| **メンバー含む** × `src/types/**` のみ | **0 件** |

この結果から、**error にできる範囲だけを対象にする**二段構成を採用した。

| 対象 | 粒度 | 設定 |
|---|---|---|
| `src/**` + `tests/**` | 型本体のみ | **error** |
| `src/types/**` | 型本体 **+ メンバー** | **error** |
| 上記以外でのメンバー単位 | — | **未適用** |

### `warn` で導入しなかった理由

テンプレートは「メンバー単位の強制は warn から始める」としているが、本プロジェクトの `static-analysis.md` は

> **警告ゼロを維持**し、守れないルールは有効にしない（`error` にするか、無効にするかの二択）

と定めている。101 件を warn で放置する運用はこれに反するため、**warn を使わず、error にできる範囲に絞る**方針を採った。範囲を広げるときは先に件数を計測して error 化できる状態にする、というルールも明記した。

### なぜ `types/` だけメンバー単位なのか

`types/` は**複数箇所から参照される共有型の置き場**であり（`typescript.md`「2 箇所目の参照で昇格」）、定義ファイルを開かずに使われるためコメントの価値が最も高い。#102 で新設したばかりで違反 0 件のため、**今なら追加コストゼロで error 化できる**。

## 既存の判断との整合

`eslint.config.mjs` には以下のコメントがあった。

```js
// require-jsdoc は // 行コメントを誤検知するため未採用。
```

今回追加するのは **`contexts` で型宣言だけを対象にした別用途**で、`require: {}` を併記して関数・クラス等の既定対象は要求しない。**関数への `require-jsdoc` は引き続き未採用**であり、この判断とは衝突しない。その旨を設定コメントと `jsdoc.md` の両方に明記した。

## 検出された 3 件の修正

いずれも「型はあるが説明が無い」実在のギャップだった。

| ファイル | 型 |
|---|---|
| `src/hooks/useAdminSession.ts` | `AdminSessionState` — `isAdmin` と `isLoading` を独立させている理由、判定中の `isAdmin` の扱いを追記 |
| `tests/setup/it-global-setup.ts` | `ProvidedContext` — vitest 型の宣言マージであること（`typescript.md` 条件 2）を明記 |
| `tests/unit/app/api/admin/export/route.test.ts` | `ExportRecord` — Prisma 戻り値の部分実装であることを明記 |

## 動作確認

| | 結果 |
|---|---|
| `pnpm lint` | エラーなし |
| `pnpm exec tsc --noEmit` | エラーなし |
| `pnpm test` | 11 files / **144 tests passed** |
| `markdownlint-cli2@0.23.1` | `0 issues` |
| **ルールの発火確認** | `src/types/` に無コメントの型を一時作成し、**型本体 1 + メンバー 1 = 2 件**検出されることを確認（設定が空振りしていないことの検証） |

## 補足

「メンバー単位を全体に広げる」は現時点では見送り。`jsdoc.md` に**広げる際の手順**（先に件数を計測して error 化できる状態にする）を書いてあるので、`types/` への型集約が進んだ段階で再検討できる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)