### PR TITLE
chore: Prettier で一括整形し CI に差分ゼロ検証を追加する

### DIFF
--- a/.claude/rules/static-analysis.md
+++ b/.claude/rules/static-analysis.md
@@ -7,9 +7,10 @@ globs:
 
 使用するツールは `coding-standards.md`（ESLint + Prettier）と `typescript.md`（`tsc --noEmit` / `typescript-eslint` / `eslint-plugin-jsdoc`）で定める。本ルールは**どう運用するか**を定める。
 
-本プロジェクトの CI 上の実体は `.github/workflows/ci.yml` の `static-check` ジョブ（`pnpm lint` → `tsc --noEmit` → `next build`）と、`.github/workflows/docs.yml` の markdown lint（`.markdownlint-cli2.jsonc`）。発火条件は `github-actions.md` に従う。
+本プロジェクトの CI 上の実体は `.github/workflows/ci.yml` の `static-check` ジョブ（`pnpm format` → `pnpm lint` → `tsc --noEmit` → `next build`）と、`.github/workflows/docs.yml` の markdown lint（`.markdownlint-cli2.jsonc`）。発火条件は `github-actions.md` に従う。
 
-> **未達の項目**: 後述「CI で必須にする」が求める **Formatter の差分ゼロ検証（`pnpm format`）が CI に入っていない**。既存コードに未整形ファイルが残っているため、一括整形と CI 追加は別途対応する（issue #87）。
+- Formatter の設定は `front/.prettierrc`、対象外は `front/.prettierignore`（生成物・実行成果物を除外する）。
+- `pnpm format` は `prettier --check .`（差分ゼロの検証のみ）。修正は `pnpm run format:fix` を手元で実行する。
 
 ## 役割分担（重ねない）
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,11 @@ jobs:
       - name: Generate Prisma client
         run: pnpm exec prisma generate
 
+      # Formatter は差分ゼロを検証する（--check）。CI が自動整形してコミットし返さない
+      # （.claude/rules/static-analysis.md）。
+      - name: Format check (Prettier)
+        run: pnpm format
+
       - name: Lint (ESLint)
         run: pnpm lint
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ pnpm dev   # http://localhost:3000
 | `pnpm run e2e:db:up` / `e2e:db:down` | E2E 用 PostgreSQL（docker-compose）の起動 / 破棄 |
 | `pnpm run test:e2e` | Playwright E2E テスト（単機能フロー、実 DB。事前に `e2e:db:up`、要 Docker） |
 | `pnpm run test:scenario` | Playwright シナリオテスト（複数機能横断、実 DB。事前に `e2e:db:up`、要 Docker） |
-| `pnpm lint` / `pnpm format` | Lint / フォーマットチェック |
+| `pnpm lint` / `pnpm format` | Lint / フォーマットチェック（いずれも CI 必須。`format` は差分ゼロを検証するのみ） |
+| `pnpm run format:fix` | Prettier で自動整形（`pnpm format` が落ちたら手元でこれを実行する） |
 
 ## DB マイグレーション
 

--- a/docs/09-architecture-specification.md
+++ b/docs/09-architecture-specification.md
@@ -86,7 +86,7 @@ GitHub Actions による自動検査。**変更内容に関係のあるジョブ
 
   | ジョブ | 内容 | 所要時間目安 |
   |--------|------|------------|
-  | `static-check` | ESLint（`pnpm lint`）→ 型チェック（`tsc --noEmit`）→ 本番ビルド（`next build`） | ~1 分 |
+  | `static-check` | フォーマット検証（`pnpm format` = `prettier --check`）→ ESLint（`pnpm lint`）→ 型チェック（`tsc --noEmit`）→ 本番ビルド（`next build`） | ~1 分 |
   | `unit-test` | Vitest ユニットテスト（モック） | ~30 秒 |
   | `it-test` | Vitest 統合テスト（Testcontainers の実 PostgreSQL、`pnpm test:it`） | ~1〜2 分 |
   | `e2e-test` | Playwright E2E テスト（単機能フロー、実 DB、`--project=e2e`） | ~7 分 |

--- a/front/.prettierignore
+++ b/front/.prettierignore
@@ -2,3 +2,11 @@
 node_modules
 pnpm-lock.yaml
 public
+
+# 生成物・実行成果物は整形対象にしない。
+# CI が `prettier --check .` で差分ゼロを検証する（.claude/rules/static-analysis.md）ため、
+# ローカルに生成物が残っているだけで検査が落ちる状態を避ける。
+src/generated
+test-results
+playwright-report
+coverage

--- a/front/README.md
+++ b/front/README.md
@@ -6,20 +6,20 @@
 
 ## ディレクトリ構成（`src/`）
 
-| パス | 役割 |
-|------|------|
-| `app/` | ルーティング（一覧 `/`、詳細 `/records/[date]`、管理者 `/admin/*`） |
-| `app/api/` | API Route Handlers（records / masters / profile / admin） |
-| `components/` | UI コンポーネント（一覧/詳細クライアント、DatePicker、`ui/` 共通部品 等） |
-| `hooks/` | `useRecordValidation` / `useAdminSession` |
-| `lib/` | `prisma` / `supabase` / `adminAuth` / `authFetch` / `validation` / `calorie` |
-| `generated/prisma/` | Prisma Client 生成物（git 管理外、`prisma generate` で生成） |
+| パス                | 役割                                                                         |
+| ------------------- | ---------------------------------------------------------------------------- |
+| `app/`              | ルーティング（一覧 `/`、詳細 `/records/[date]`、管理者 `/admin/*`）          |
+| `app/api/`          | API Route Handlers（records / masters / profile / admin）                    |
+| `components/`       | UI コンポーネント（一覧/詳細クライアント、DatePicker、`ui/` 共通部品 等）    |
+| `hooks/`            | `useRecordValidation` / `useAdminSession`                                    |
+| `lib/`              | `prisma` / `supabase` / `adminAuth` / `authFetch` / `validation` / `calorie` |
+| `generated/prisma/` | Prisma Client 生成物（git 管理外、`prisma generate` で生成）                 |
 
 ## テスト
 
-| 種別 | 配置 |
-|------|------|
-| ユニット（Vitest） | `tests/unit/`, `tests/it/`, `tests/setup/` |
-| E2E（Playwright） | `tests/e2e/`（`smoke.spec.ts` / `record-crud.spec.ts`） |
+| 種別               | 配置                                                    |
+| ------------------ | ------------------------------------------------------- |
+| ユニット（Vitest） | `tests/unit/`, `tests/it/`, `tests/setup/`              |
+| E2E（Playwright）  | `tests/e2e/`（`smoke.spec.ts` / `record-crud.spec.ts`） |
 
 詳細は [`../docs/08-test-specification.md`](../docs/08-test-specification.md) を参照。

--- a/front/eslint.config.mjs
+++ b/front/eslint.config.mjs
@@ -1,7 +1,7 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import nextVitals from "eslint-config-next/core-web-vitals";
-import nextTs from "eslint-config-next/typescript";
-import jsdoc from "eslint-plugin-jsdoc";
+import { defineConfig, globalIgnores } from 'eslint/config';
+import nextVitals from 'eslint-config-next/core-web-vitals';
+import nextTs from 'eslint-config-next/typescript';
+import jsdoc from 'eslint-plugin-jsdoc';
 
 const eslintConfig = defineConfig([
   ...nextVitals,
@@ -12,32 +12,32 @@ const eslintConfig = defineConfig([
     // tests/ も対象に含める。テストを src からここへ集約した際、対象が src/** のままだと
     // テストコードが黙って JSDoc ルールの対象外になるため（jsdoc.md「混乱テスト」は
     // テスト足場にも "why" を求めている）。
-    files: ["src/**/*.{ts,tsx}", "tests/**/*.{ts,tsx}"],
+    files: ['src/**/*.{ts,tsx}', 'tests/**/*.{ts,tsx}'],
     plugins: { jsdoc },
     // TS 前提。型は JSDoc ではなくシグネチャに委ねる。
-    settings: { jsdoc: { mode: "typescript" } },
+    settings: { jsdoc: { mode: 'typescript' } },
     rules: {
       // 型の再掲を禁止（TS シグネチャが型の唯一の真実）。
-      "jsdoc/no-types": "error",
+      'jsdoc/no-types': 'error',
       // JSDoc ブロックを持つ関数は全引数を @param で説明する。
       // 分割代入 props は型（XxxProps）が真実なので props.x 単位には展開しない。
-      "jsdoc/require-param": ["error", { checkDestructured: false, checkDestructuredRoots: false }],
-      "jsdoc/require-param-description": "error",
+      'jsdoc/require-param': ['error', { checkDestructured: false, checkDestructuredRoots: false }],
+      'jsdoc/require-param-description': 'error',
       // @param 名と実引数名を突き合わせる（名前ズレ・順序・過不足を検出）。
-      "jsdoc/check-param-names": "error",
+      'jsdoc/check-param-names': 'error',
       // 返り値がある関数は @returns に意味を書く（.tsx コンポーネントは後続ブロックで除外）。
-      "jsdoc/require-returns": "error",
-      "jsdoc/require-returns-description": "error",
+      'jsdoc/require-returns': 'error',
+      'jsdoc/require-returns-description': 'error',
       // 書いた JSDoc の体裁を整える。
-      "jsdoc/check-alignment": "warn",
-      "jsdoc/no-multi-asterisks": "warn",
+      'jsdoc/check-alignment': 'warn',
+      'jsdoc/no-multi-asterisks': 'warn',
       // 型本体（type / interface の宣言）に JSDoc を必須にする。
       // require: {} で関数・クラス等の既定対象は要求せず、contexts で型宣言だけを対象にする。
       // 関数に対する require-jsdoc は // 行コメントを誤検知するため引き続き未採用で、
       // 関数の JSDoc ブロックの有無・質はレビューで確認する。
-      "jsdoc/require-jsdoc": [
-        "error",
-        { require: {}, contexts: ["TSTypeAliasDeclaration", "TSInterfaceDeclaration"] },
+      'jsdoc/require-jsdoc': [
+        'error',
+        { require: {}, contexts: ['TSTypeAliasDeclaration', 'TSInterfaceDeclaration'] },
       ],
     },
   },
@@ -48,17 +48,13 @@ const eslintConfig = defineConfig([
     // 定義ファイルを開かずに使われるためコメントの価値が最も高い。
     // static-analysis.md「警告ゼロを維持し、守れないルールは有効にしない」に従い、
     // warn で放置せず error にできる範囲だけを対象にしている（現状 0 件）。
-    files: ["src/types/**/*.ts"],
+    files: ['src/types/**/*.ts'],
     rules: {
-      "jsdoc/require-jsdoc": [
-        "error",
+      'jsdoc/require-jsdoc': [
+        'error',
         {
           require: {},
-          contexts: [
-            "TSTypeAliasDeclaration",
-            "TSInterfaceDeclaration",
-            "TSPropertySignature",
-          ],
+          contexts: ['TSTypeAliasDeclaration', 'TSInterfaceDeclaration', 'TSPropertySignature'],
         },
       ],
     },
@@ -66,22 +62,22 @@ const eslintConfig = defineConfig([
   {
     // React コンポーネント（JSX を返す .tsx）は @returns を要求しない（「@returns …の要素」はノイズ）。
     // .ts のフック / lib / API では @returns 必須のまま。
-    files: ["src/**/*.tsx", "tests/**/*.tsx"],
+    files: ['src/**/*.tsx', 'tests/**/*.tsx'],
     rules: {
-      "jsdoc/require-returns": "off",
-      "jsdoc/require-returns-description": "off",
+      'jsdoc/require-returns': 'off',
+      'jsdoc/require-returns-description': 'off',
     },
   },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:
-    ".next/**",
-    "out/**",
-    "build/**",
-    "next-env.d.ts",
+    '.next/**',
+    'out/**',
+    'build/**',
+    'next-env.d.ts',
     // Prisma 自動生成コード（.gitignore 済みのビルド成果物）は lint 対象外にする。
     // JSDoc/型ルール等が生成コードを誤検知するため除外する。
-    "src/generated/**",
+    'src/generated/**',
   ]),
 ]);
 

--- a/front/next.config.ts
+++ b/front/next.config.ts
@@ -1,4 +1,4 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   /* config options here */

--- a/front/postcss.config.mjs
+++ b/front/postcss.config.mjs
@@ -1,6 +1,6 @@
 const config = {
   plugins: {
-    "@tailwindcss/postcss": {},
+    '@tailwindcss/postcss': {},
   },
 };
 

--- a/front/src/app/admin/export/page.tsx
+++ b/front/src/app/admin/export/page.tsx
@@ -29,9 +29,7 @@ export default function AdminExportPage() {
     }
     setStatus('loading');
     setMessage('');
-    const res = await authFetch(
-      `/api/admin/export?from=${fromDate}&to=${toDate}&format=${format}`,
-    );
+    const res = await authFetch(`/api/admin/export?from=${fromDate}&to=${toDate}&format=${format}`);
     if (!res.ok) {
       setStatus('idle');
       setMessage('エクスポートに失敗しました。');
@@ -120,9 +118,7 @@ export default function AdminExportPage() {
           </div>
         </Card>
 
-        {message ? (
-          <p className="mt-4 text-sm font-bold text-gray-500">{message}</p>
-        ) : null}
+        {message ? <p className="mt-4 text-sm font-bold text-gray-500">{message}</p> : null}
 
         <div className="mt-8 flex justify-end">
           <button

--- a/front/src/app/admin/login/page.tsx
+++ b/front/src/app/admin/login/page.tsx
@@ -91,9 +91,7 @@ export default function AdminLoginPage() {
 
       <section className="mx-auto max-w-xl px-6 pt-8">
         <Card className="p-8 text-center">
-          <p className="text-sm font-bold text-gray-500">
-            Google アカウントでログインしてください
-          </p>
+          <p className="text-sm font-bold text-gray-500">Google アカウントでログインしてください</p>
           <button
             type="button"
             className={`mt-6 ${buttonClasses('primary')} flex items-center gap-2 rounded-2xl px-6 py-3 text-sm`}

--- a/front/src/app/admin/masters/page.tsx
+++ b/front/src/app/admin/masters/page.tsx
@@ -283,7 +283,11 @@ export default function AdminMastersPage() {
                           disabled={deletingId === item.id}
                         >
                           {deletingId === item.id ? (
-                            <LoadingSpinner mode="deleting" variant="inline" className="text-inherit" />
+                            <LoadingSpinner
+                              mode="deleting"
+                              variant="inline"
+                              className="text-inherit"
+                            />
                           ) : (
                             <>
                               <Trash2 size={14} />

--- a/front/src/app/admin/records/[date]/edit/page.tsx
+++ b/front/src/app/admin/records/[date]/edit/page.tsx
@@ -47,7 +47,14 @@ type RecordDetail = {
   /** 体調メモ（未入力時は `null`）。 */
   memo: string | null;
   /** 筋トレ項目（数値はサーバー保存値のため number）。 */
-  workouts: { id: string; part: string; name: string; sets: number; reps: number; weight: number }[];
+  workouts: {
+    id: string;
+    part: string;
+    name: string;
+    sets: number;
+    reps: number;
+    weight: number;
+  }[];
   /** 有酸素項目（数値はサーバー保存値のため number）。 */
   cardios: { type: string; minutes: number; distance: number }[];
 };
@@ -128,12 +135,14 @@ export default function AdminRecordEditPage({ params }: PageProps) {
       setWorkouts(data.workouts.length ? data.workouts.map(toRow) : [emptyRow()]);
       setMemo(data.memo ?? '');
       if (data.cardios?.length) {
-        setCardios(data.cardios.map((c) => ({
-          id: crypto.randomUUID(),
-          type: (c.type === 'ウォーク' ? 'ウォーク' : 'ラン') as 'ラン' | 'ウォーク',
-          minutes: String(c.minutes),
-          distance: String(c.distance),
-        })));
+        setCardios(
+          data.cardios.map((c) => ({
+            id: crypto.randomUUID(),
+            type: (c.type === 'ウォーク' ? 'ウォーク' : 'ラン') as 'ラン' | 'ウォーク',
+            minutes: String(c.minutes),
+            distance: String(c.distance),
+          })),
+        );
       }
       setLoading(false);
     };
@@ -149,9 +158,7 @@ export default function AdminRecordEditPage({ params }: PageProps) {
   );
 
   const updateWorkout = (id: string, field: keyof WorkoutRow, value: string) => {
-    setWorkouts((prev) =>
-      prev.map((row) => (row.id === id ? { ...row, [field]: value } : row)),
-    );
+    setWorkouts((prev) => prev.map((row) => (row.id === id ? { ...row, [field]: value } : row)));
   };
 
   const addRow = () => setWorkouts((prev) => [...prev, emptyRow()]);
@@ -159,13 +166,10 @@ export default function AdminRecordEditPage({ params }: PageProps) {
     setWorkouts((prev) => (prev.length === 1 ? prev : prev.filter((row) => row.id !== id)));
 
   const updateCardio = (id: string, field: keyof CardioRow, value: string) => {
-    setCardios((prev) =>
-      prev.map((row) => (row.id === id ? { ...row, [field]: value } : row)),
-    );
+    setCardios((prev) => prev.map((row) => (row.id === id ? { ...row, [field]: value } : row)));
   };
   const addCardioRow = () => setCardios((prev) => [...prev, createCardioRow()]);
-  const removeCardioRow = (id: string) =>
-    setCardios((prev) => prev.filter((row) => row.id !== id));
+  const removeCardioRow = (id: string) => setCardios((prev) => prev.filter((row) => row.id !== id));
 
   const handleSave = async () => {
     setSubmitted(true);
@@ -279,7 +283,9 @@ export default function AdminRecordEditPage({ params }: PageProps) {
                         <option value="腹">腹</option>
                       </select>
                       {displayErrors.workouts[row.id]?.part ? (
-                        <p className="mt-1 text-xs text-red-500">{displayErrors.workouts[row.id].part}</p>
+                        <p className="mt-1 text-xs text-red-500">
+                          {displayErrors.workouts[row.id].part}
+                        </p>
                       ) : null}
                     </label>
                     <label className="text-[10px] font-black uppercase text-gray-400 md:col-span-2">
@@ -292,7 +298,9 @@ export default function AdminRecordEditPage({ params }: PageProps) {
                         onChange={(event) => updateWorkout(row.id, 'name', event.target.value)}
                       />
                       {displayErrors.workouts[row.id]?.name ? (
-                        <p className="mt-1 text-xs text-red-500">{displayErrors.workouts[row.id].name}</p>
+                        <p className="mt-1 text-xs text-red-500">
+                          {displayErrors.workouts[row.id].name}
+                        </p>
                       ) : null}
                     </label>
                     <label className="text-[10px] font-black uppercase text-gray-400">
@@ -305,7 +313,9 @@ export default function AdminRecordEditPage({ params }: PageProps) {
                         onChange={(event) => updateWorkout(row.id, 'sets', event.target.value)}
                       />
                       {displayErrors.workouts[row.id]?.sets ? (
-                        <p className="mt-1 text-xs text-red-500">{displayErrors.workouts[row.id].sets}</p>
+                        <p className="mt-1 text-xs text-red-500">
+                          {displayErrors.workouts[row.id].sets}
+                        </p>
                       ) : null}
                     </label>
                     <label className="text-[10px] font-black uppercase text-gray-400">
@@ -318,7 +328,9 @@ export default function AdminRecordEditPage({ params }: PageProps) {
                         onChange={(event) => updateWorkout(row.id, 'reps', event.target.value)}
                       />
                       {displayErrors.workouts[row.id]?.reps ? (
-                        <p className="mt-1 text-xs text-red-500">{displayErrors.workouts[row.id].reps}</p>
+                        <p className="mt-1 text-xs text-red-500">
+                          {displayErrors.workouts[row.id].reps}
+                        </p>
                       ) : null}
                     </label>
                     <label className="text-[10px] font-black uppercase text-gray-400">
@@ -331,7 +343,9 @@ export default function AdminRecordEditPage({ params }: PageProps) {
                         onChange={(event) => updateWorkout(row.id, 'weight', event.target.value)}
                       />
                       {displayErrors.workouts[row.id]?.weight ? (
-                        <p className="mt-1 text-xs text-red-500">{displayErrors.workouts[row.id].weight}</p>
+                        <p className="mt-1 text-xs text-red-500">
+                          {displayErrors.workouts[row.id].weight}
+                        </p>
                       ) : null}
                     </label>
                   </div>
@@ -371,9 +385,7 @@ export default function AdminRecordEditPage({ params }: PageProps) {
                       <select
                         className="mt-2 w-full rounded-lg border-none bg-white p-2 text-sm font-bold"
                         value={row.type}
-                        onChange={(event) =>
-                          updateCardio(row.id, 'type', event.target.value)
-                        }
+                        onChange={(event) => updateCardio(row.id, 'type', event.target.value)}
                       >
                         <option value="ラン">ラン</option>
                         <option value="ウォーク">ウォーク</option>
@@ -389,7 +401,9 @@ export default function AdminRecordEditPage({ params }: PageProps) {
                         onChange={(event) => updateCardio(row.id, 'minutes', event.target.value)}
                       />
                       {displayErrors.cardios[row.id]?.minutes ? (
-                        <p className="mt-1 text-xs text-red-500">{displayErrors.cardios[row.id].minutes}</p>
+                        <p className="mt-1 text-xs text-red-500">
+                          {displayErrors.cardios[row.id].minutes}
+                        </p>
                       ) : null}
                     </label>
                     <label className="text-[10px] font-black uppercase text-gray-400">
@@ -402,7 +416,9 @@ export default function AdminRecordEditPage({ params }: PageProps) {
                         onChange={(event) => updateCardio(row.id, 'distance', event.target.value)}
                       />
                       {displayErrors.cardios[row.id]?.distance ? (
-                        <p className="mt-1 text-xs text-red-500">{displayErrors.cardios[row.id].distance}</p>
+                        <p className="mt-1 text-xs text-red-500">
+                          {displayErrors.cardios[row.id].distance}
+                        </p>
                       ) : null}
                     </label>
                   </div>

--- a/front/src/app/admin/records/new/page.tsx
+++ b/front/src/app/admin/records/new/page.tsx
@@ -88,9 +88,7 @@ export default function AdminRecordNewPage() {
   );
 
   const updateWorkout = (id: string, field: keyof WorkoutRow, value: string) => {
-    setWorkouts((prev) =>
-      prev.map((row) => (row.id === id ? { ...row, [field]: value } : row)),
-    );
+    setWorkouts((prev) => prev.map((row) => (row.id === id ? { ...row, [field]: value } : row)));
   };
 
   const addRow = () => setWorkouts((prev) => [...prev, createRow()]);
@@ -98,13 +96,10 @@ export default function AdminRecordNewPage() {
     setWorkouts((prev) => (prev.length === 1 ? prev : prev.filter((row) => row.id !== id)));
 
   const updateCardio = (id: string, field: keyof CardioRow, value: string) => {
-    setCardios((prev) =>
-      prev.map((row) => (row.id === id ? { ...row, [field]: value } : row)),
-    );
+    setCardios((prev) => prev.map((row) => (row.id === id ? { ...row, [field]: value } : row)));
   };
   const addCardioRow = () => setCardios((prev) => [...prev, createCardioRow()]);
-  const removeCardioRow = (id: string) =>
-    setCardios((prev) => prev.filter((row) => row.id !== id));
+  const removeCardioRow = (id: string) => setCardios((prev) => prev.filter((row) => row.id !== id));
 
   const handleSave = async () => {
     setSubmitted(true);
@@ -206,7 +201,9 @@ export default function AdminRecordNewPage() {
                         <option value="腹">腹</option>
                       </select>
                       {displayErrors.workouts[row.id]?.part ? (
-                        <p className="mt-1 text-xs text-red-500">{displayErrors.workouts[row.id].part}</p>
+                        <p className="mt-1 text-xs text-red-500">
+                          {displayErrors.workouts[row.id].part}
+                        </p>
                       ) : null}
                     </label>
                     <label className="text-[10px] font-black uppercase text-gray-400 md:col-span-2">
@@ -219,7 +216,9 @@ export default function AdminRecordNewPage() {
                         onChange={(event) => updateWorkout(row.id, 'name', event.target.value)}
                       />
                       {displayErrors.workouts[row.id]?.name ? (
-                        <p className="mt-1 text-xs text-red-500">{displayErrors.workouts[row.id].name}</p>
+                        <p className="mt-1 text-xs text-red-500">
+                          {displayErrors.workouts[row.id].name}
+                        </p>
                       ) : null}
                     </label>
                     <label className="text-[10px] font-black uppercase text-gray-400">
@@ -232,7 +231,9 @@ export default function AdminRecordNewPage() {
                         onChange={(event) => updateWorkout(row.id, 'sets', event.target.value)}
                       />
                       {displayErrors.workouts[row.id]?.sets ? (
-                        <p className="mt-1 text-xs text-red-500">{displayErrors.workouts[row.id].sets}</p>
+                        <p className="mt-1 text-xs text-red-500">
+                          {displayErrors.workouts[row.id].sets}
+                        </p>
                       ) : null}
                     </label>
                     <label className="text-[10px] font-black uppercase text-gray-400">
@@ -245,7 +246,9 @@ export default function AdminRecordNewPage() {
                         onChange={(event) => updateWorkout(row.id, 'reps', event.target.value)}
                       />
                       {displayErrors.workouts[row.id]?.reps ? (
-                        <p className="mt-1 text-xs text-red-500">{displayErrors.workouts[row.id].reps}</p>
+                        <p className="mt-1 text-xs text-red-500">
+                          {displayErrors.workouts[row.id].reps}
+                        </p>
                       ) : null}
                     </label>
                     <label className="text-[10px] font-black uppercase text-gray-400">
@@ -258,7 +261,9 @@ export default function AdminRecordNewPage() {
                         onChange={(event) => updateWorkout(row.id, 'weight', event.target.value)}
                       />
                       {displayErrors.workouts[row.id]?.weight ? (
-                        <p className="mt-1 text-xs text-red-500">{displayErrors.workouts[row.id].weight}</p>
+                        <p className="mt-1 text-xs text-red-500">
+                          {displayErrors.workouts[row.id].weight}
+                        </p>
                       ) : null}
                     </label>
                   </div>
@@ -298,9 +303,7 @@ export default function AdminRecordNewPage() {
                       <select
                         className="mt-2 w-full rounded-lg border-none bg-white p-2 text-sm font-bold"
                         value={row.type}
-                        onChange={(event) =>
-                          updateCardio(row.id, 'type', event.target.value)
-                        }
+                        onChange={(event) => updateCardio(row.id, 'type', event.target.value)}
                       >
                         <option value="ラン">ラン</option>
                         <option value="ウォーク">ウォーク</option>
@@ -316,7 +319,9 @@ export default function AdminRecordNewPage() {
                         onChange={(event) => updateCardio(row.id, 'minutes', event.target.value)}
                       />
                       {displayErrors.cardios[row.id]?.minutes ? (
-                        <p className="mt-1 text-xs text-red-500">{displayErrors.cardios[row.id].minutes}</p>
+                        <p className="mt-1 text-xs text-red-500">
+                          {displayErrors.cardios[row.id].minutes}
+                        </p>
                       ) : null}
                     </label>
                     <label className="text-[10px] font-black uppercase text-gray-400">
@@ -329,7 +334,9 @@ export default function AdminRecordNewPage() {
                         onChange={(event) => updateCardio(row.id, 'distance', event.target.value)}
                       />
                       {displayErrors.cardios[row.id]?.distance ? (
-                        <p className="mt-1 text-xs text-red-500">{displayErrors.cardios[row.id].distance}</p>
+                        <p className="mt-1 text-xs text-red-500">
+                          {displayErrors.cardios[row.id].distance}
+                        </p>
                       ) : null}
                     </label>
                   </div>

--- a/front/src/app/api/records/[date]/route.ts
+++ b/front/src/app/api/records/[date]/route.ts
@@ -45,21 +45,19 @@ export async function GET(_request: Request, context: RouteContext) {
         reps: number;
         weight: number;
       }) => ({
-      id: workout.id,
-      part: workout.part,
-      name: workout.name,
-      sets: workout.sets,
-      reps: workout.reps,
-      weight: workout.weight,
-    }),
-    ),
-    cardios: record.cardios.map(
-      (c: { type: string; minutes: number; distance: number }) => ({
-        type: c.type,
-        minutes: c.minutes,
-        distance: c.distance,
+        id: workout.id,
+        part: workout.part,
+        name: workout.name,
+        sets: workout.sets,
+        reps: workout.reps,
+        weight: workout.weight,
       }),
     ),
+    cardios: record.cardios.map((c: { type: string; minutes: number; distance: number }) => ({
+      type: c.type,
+      minutes: c.minutes,
+      distance: c.distance,
+    })),
   });
 }
 
@@ -141,8 +139,7 @@ export async function PATCH(request: Request, context: RouteContext) {
 
     return NextResponse.json({ id: updated.id });
   } catch (error: unknown) {
-    const message =
-      error instanceof Error ? error.message : String(error);
+    const message = error instanceof Error ? error.message : String(error);
     console.error('PATCH /api/records/:date error:', message);
     return NextResponse.json({ error: message }, { status: 500 });
   }

--- a/front/src/app/api/records/route.ts
+++ b/front/src/app/api/records/route.ts
@@ -41,16 +41,16 @@ export async function GET(request: Request) {
       workouts: { sets: number }[];
       cardios: { type: string; minutes: number; distance: number }[];
     }) => ({
-    date: record.date.toISOString().slice(0, 10),
-    totalSets: record.workouts.reduce((sum, workout) => sum + workout.sets, 0),
-    cardioMinutes: record.cardios.reduce((sum, c) => sum + c.minutes, 0),
-    cardioDistance: record.cardios.reduce((sum, c) => sum + c.distance, 0),
-    cardios: record.cardios.map((c) => ({
-      type: c.type,
-      minutes: c.minutes,
-      distance: c.distance,
-    })),
-  }),
+      date: record.date.toISOString().slice(0, 10),
+      totalSets: record.workouts.reduce((sum, workout) => sum + workout.sets, 0),
+      cardioMinutes: record.cardios.reduce((sum, c) => sum + c.minutes, 0),
+      cardioDistance: record.cardios.reduce((sum, c) => sum + c.distance, 0),
+      cardios: record.cardios.map((c) => ({
+        type: c.type,
+        minutes: c.minutes,
+        distance: c.distance,
+      })),
+    }),
   );
 
   return NextResponse.json({ records: result, totalCount, page, totalPages });
@@ -128,8 +128,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ id: record.id });
   } catch (error: unknown) {
-    const message =
-      error instanceof Error ? error.message : String(error);
+    const message = error instanceof Error ? error.message : String(error);
     console.error('POST /api/records error:', message);
     return NextResponse.json({ error: message }, { status: 500 });
   }

--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 :root {
   --background: #f9fafb;
@@ -8,7 +8,7 @@
   --accent-strong: #432472;
   --accent-pink: #eb008b;
   --muted: #6b7280;
-  --font-body: system-ui, -apple-system, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  --font-body: system-ui, -apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
 }
 
 @theme inline {

--- a/front/src/components/AdminRecordsListClient.tsx
+++ b/front/src/components/AdminRecordsListClient.tsx
@@ -41,35 +41,38 @@ export default function AdminRecordsListClient() {
 
   const currentPage = Number(searchParams.get('page') ?? 1) || 1;
 
-  const fetchRecords = useCallback(async (p: number) => {
-    setHasFetched(false);
-    try {
-      const res = await fetch(`/api/records?page=${p}`);
-      if (!res.ok) {
+  const fetchRecords = useCallback(
+    async (p: number) => {
+      setHasFetched(false);
+      try {
+        const res = await fetch(`/api/records?page=${p}`);
+        if (!res.ok) {
+          setError('記録の取得に失敗しました。');
+          setRecords([]);
+          setHasFetched(true);
+          return;
+        }
+        const data = (await res.json()) as {
+          records: AdminRecordSummary[];
+          page: number;
+          totalPages: number;
+        };
+        setRecords(data.records);
+        setPage(data.page);
+        setTotalPages(data.totalPages);
+        setHasFetched(true);
+
+        if (data.page !== p) {
+          router.replace(`/admin/records?page=${data.page}`);
+        }
+      } catch {
         setError('記録の取得に失敗しました。');
         setRecords([]);
         setHasFetched(true);
-        return;
       }
-      const data = (await res.json()) as {
-        records: AdminRecordSummary[];
-        page: number;
-        totalPages: number;
-      };
-      setRecords(data.records);
-      setPage(data.page);
-      setTotalPages(data.totalPages);
-      setHasFetched(true);
-
-      if (data.page !== p) {
-        router.replace(`/admin/records?page=${data.page}`);
-      }
-    } catch {
-      setError('記録の取得に失敗しました。');
-      setRecords([]);
-      setHasFetched(true);
-    }
-  }, [router]);
+    },
+    [router],
+  );
 
   useEffect(() => {
     // URL の page 変化に応じてサーバーからデータを再取得する正当な副作用。
@@ -154,59 +157,62 @@ export default function AdminRecordsListClient() {
               </p>
             </Card>
           ) : null}
-          {records.length > 0 && records.map((record) => (
-            <Card key={record.date} className="p-6 md:p-8">
-              <div className="flex flex-wrap items-center justify-between gap-4">
-                <div>
-                  <p className="text-[10px] font-black uppercase tracking-[0.2em] text-gray-400">日付</p>
-                  <h2 className="text-2xl font-black text-gray-900">{record.date}</h2>
+          {records.length > 0 &&
+            records.map((record) => (
+              <Card key={record.date} className="p-6 md:p-8">
+                <div className="flex flex-wrap items-center justify-between gap-4">
+                  <div>
+                    <p className="text-[10px] font-black uppercase tracking-[0.2em] text-gray-400">
+                      日付
+                    </p>
+                    <h2 className="text-2xl font-black text-gray-900">{record.date}</h2>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <Link href={`/records/${record.date}`} className={buttonClasses('outline')}>
+                      詳細を見る
+                    </Link>
+                    <Link
+                      href={`/admin/records/${record.date}/edit`}
+                      className="rounded-full border border-[#8a6f3c] px-4 py-2 text-sm font-bold text-[#8a6f3c] transition hover:bg-[#8a6f3c] hover:text-white"
+                    >
+                      編集
+                    </Link>
+                    <button
+                      type="button"
+                      className={buttonClasses('danger')}
+                      onClick={() => handleDelete(record.date)}
+                      disabled={deletingDate === record.date}
+                    >
+                      {deletingDate === record.date ? (
+                        <LoadingSpinner mode="deleting" variant="inline" className="text-inherit" />
+                      ) : (
+                        '削除'
+                      )}
+                    </button>
+                  </div>
                 </div>
-                <div className="flex flex-wrap gap-2">
-                  <Link href={`/records/${record.date}`} className={buttonClasses('outline')}>
-                    詳細を見る
-                  </Link>
-                  <Link
-                    href={`/admin/records/${record.date}/edit`}
-                    className="rounded-full border border-[#8a6f3c] px-4 py-2 text-sm font-bold text-[#8a6f3c] transition hover:bg-[#8a6f3c] hover:text-white"
-                  >
-                    編集
-                  </Link>
-                  <button
-                    type="button"
-                    className={buttonClasses('danger')}
-                    onClick={() => handleDelete(record.date)}
-                    disabled={deletingDate === record.date}
-                  >
-                    {deletingDate === record.date ? (
-                      <LoadingSpinner mode="deleting" variant="inline" className="text-inherit" />
-                    ) : (
-                      '削除'
-                    )}
-                  </button>
+                <div className="mt-6 grid gap-4 md:grid-cols-3">
+                  <div className="rounded-2xl bg-gray-50 p-4 text-center">
+                    <p className="text-[10px] font-black uppercase text-gray-400">合計セット数</p>
+                    <p className="mt-2 text-2xl font-black text-[color:var(--accent)]">
+                      {record.totalSets}セット
+                    </p>
+                  </div>
+                  <div className="rounded-2xl bg-gray-50 p-4 text-center">
+                    <p className="text-[10px] font-black uppercase text-gray-400">有酸素合計時間</p>
+                    <p className="mt-2 text-2xl font-black text-[color:var(--accent)]">
+                      {record.cardioMinutes}分
+                    </p>
+                  </div>
+                  <div className="rounded-2xl bg-gray-50 p-4 text-center">
+                    <p className="text-[10px] font-black uppercase text-gray-400">有酸素合計距離</p>
+                    <p className="mt-2 text-2xl font-black text-[color:var(--accent)]">
+                      {record.cardioDistance}km
+                    </p>
+                  </div>
                 </div>
-              </div>
-              <div className="mt-6 grid gap-4 md:grid-cols-3">
-                <div className="rounded-2xl bg-gray-50 p-4 text-center">
-                  <p className="text-[10px] font-black uppercase text-gray-400">合計セット数</p>
-                  <p className="mt-2 text-2xl font-black text-[color:var(--accent)]">
-                    {record.totalSets}セット
-                  </p>
-                </div>
-                <div className="rounded-2xl bg-gray-50 p-4 text-center">
-                  <p className="text-[10px] font-black uppercase text-gray-400">有酸素合計時間</p>
-                  <p className="mt-2 text-2xl font-black text-[color:var(--accent)]">
-                    {record.cardioMinutes}分
-                  </p>
-                </div>
-                <div className="rounded-2xl bg-gray-50 p-4 text-center">
-                  <p className="text-[10px] font-black uppercase text-gray-400">有酸素合計距離</p>
-                  <p className="mt-2 text-2xl font-black text-[color:var(--accent)]">
-                    {record.cardioDistance}km
-                  </p>
-                </div>
-              </div>
-            </Card>
-          ))}
+              </Card>
+            ))}
 
           {hasFetched && totalPages > 1 ? (
             <div className="mt-8 flex items-center justify-center gap-4">

--- a/front/src/components/CalorieEstimate.tsx
+++ b/front/src/components/CalorieEstimate.tsx
@@ -30,10 +30,7 @@ type CalorieEstimateProps = {
  * プロフィール API から体重を取得し、筋トレ + 有酸素の合計を算定する。体重未取得の間は
  * `-- kcal` を表示する。props の各項目は {@link CalorieEstimateProps} を参照。
  */
-export default function CalorieEstimate({
-  totalSets,
-  cardios,
-}: CalorieEstimateProps) {
+export default function CalorieEstimate({ totalSets, cardios }: CalorieEstimateProps) {
   const [weightKg, setWeightKg] = useState<number | null>(null);
 
   useEffect(() => {

--- a/front/src/components/RecordDetailClient.tsx
+++ b/front/src/components/RecordDetailClient.tsx
@@ -95,10 +95,7 @@ export default function RecordDetailClient({ date }: RecordDetailClientProps) {
   const cardios = detail?.cardios ?? [];
   const memo = detail?.memo ?? '';
 
-  const totalSets = useMemo(
-    () => workouts.reduce((sum, item) => sum + item.sets, 0),
-    [workouts],
-  );
+  const totalSets = useMemo(() => workouts.reduce((sum, item) => sum + item.sets, 0), [workouts]);
 
   return (
     <main className="min-h-screen pb-16">
@@ -128,7 +125,9 @@ export default function RecordDetailClient({ date }: RecordDetailClientProps) {
               <Card className="p-6 md:p-8">
                 <div className="flex items-center justify-between">
                   <div>
-                    <p className="text-[10px] font-black uppercase tracking-[0.2em] text-gray-400">日付</p>
+                    <p className="text-[10px] font-black uppercase tracking-[0.2em] text-gray-400">
+                      日付
+                    </p>
                     <h2 className="text-2xl font-black text-gray-900">{detail?.date ?? date}</h2>
                   </div>
                   {isAdmin ? (
@@ -146,7 +145,9 @@ export default function RecordDetailClient({ date }: RecordDetailClientProps) {
                 <CalorieEstimate
                   totalSets={totalSets}
                   cardios={cardios.map((c) => ({
-                    type: (c.type === 'ウォーク' ? 'ウォーク' : 'ラン') as import('@/lib/calorie').CardioType,
+                    type: (c.type === 'ウォーク'
+                      ? 'ウォーク'
+                      : 'ラン') as import('@/lib/calorie').CardioType,
                     minutes: c.minutes,
                   }))}
                 />

--- a/front/src/components/RecordsListClient.tsx
+++ b/front/src/components/RecordsListClient.tsx
@@ -47,37 +47,40 @@ export default function RecordsListClient() {
 
   const currentPage = Number(searchParams.get('page') ?? 1) || 1;
 
-  const fetchRecords = useCallback(async (p: number) => {
-    setHasFetched(false);
-    try {
-      const res = await fetch(`/api/records?page=${p}`);
-      if (!res.ok) {
+  const fetchRecords = useCallback(
+    async (p: number) => {
+      setHasFetched(false);
+      try {
+        const res = await fetch(`/api/records?page=${p}`);
+        if (!res.ok) {
+          setErrorMessage('記録の取得に失敗しました。');
+          setRecords([]);
+          setHasFetched(true);
+          return;
+        }
+        const data = (await res.json()) as {
+          records: RecordSummary[];
+          page: number;
+          totalPages: number;
+        };
+        setErrorMessage('');
+        setRecords(data.records);
+        setPage(data.page);
+        setTotalPages(data.totalPages);
+        setHasFetched(true);
+
+        // Correct URL if API clamped the page
+        if (data.page !== p) {
+          router.replace(data.page === 1 ? '/' : `/?page=${data.page}`);
+        }
+      } catch {
         setErrorMessage('記録の取得に失敗しました。');
         setRecords([]);
         setHasFetched(true);
-        return;
       }
-      const data = (await res.json()) as {
-        records: RecordSummary[];
-        page: number;
-        totalPages: number;
-      };
-      setErrorMessage('');
-      setRecords(data.records);
-      setPage(data.page);
-      setTotalPages(data.totalPages);
-      setHasFetched(true);
-
-      // Correct URL if API clamped the page
-      if (data.page !== p) {
-        router.replace(data.page === 1 ? '/' : `/?page=${data.page}`);
-      }
-    } catch {
-      setErrorMessage('記録の取得に失敗しました。');
-      setRecords([]);
-      setHasFetched(true);
-    }
-  }, [router]);
+    },
+    [router],
+  );
 
   useEffect(() => {
     // URL の page 変化に応じてサーバーからデータを再取得する正当な副作用。
@@ -181,7 +184,9 @@ export default function RecordsListClient() {
                   <CalorieEstimate
                     totalSets={record.totalSets}
                     cardios={(record.cardios ?? []).map((c) => ({
-                      type: (c.type === 'ウォーク' ? 'ウォーク' : 'ラン') as import('@/lib/calorie').CardioType,
+                      type: (c.type === 'ウォーク'
+                        ? 'ウォーク'
+                        : 'ラン') as import('@/lib/calorie').CardioType,
                       minutes: c.minutes,
                     }))}
                   />

--- a/front/src/components/ui/Button.tsx
+++ b/front/src/components/ui/Button.tsx
@@ -7,7 +7,8 @@ const base = 'rounded-full px-4 py-2 text-sm font-bold transition inline-flex it
 
 const variants: Record<ButtonVariant, string> = {
   primary: 'af-button shadow-lg',
-  outline: 'border border-[color:var(--accent)] text-[color:var(--accent)] hover:bg-[color:var(--accent)] hover:text-white',
+  outline:
+    'border border-[color:var(--accent)] text-[color:var(--accent)] hover:bg-[color:var(--accent)] hover:text-white',
   pink: 'bg-[color:var(--accent-pink)] text-white shadow-lg shadow-pink-100 hover:opacity-90',
   danger: 'border border-[#a94040] text-[#a94040] hover:bg-[#a94040] hover:text-white',
 };
@@ -20,8 +21,7 @@ const variants: Record<ButtonVariant, string> = {
  * @param variant - 適用する見た目バリアント（既定は `primary`）
  * @returns 共通クラスとバリアント別クラスを連結した文字列
  */
-export const buttonClasses = (variant: ButtonVariant = 'primary') =>
-  `${base} ${variants[variant]}`;
+export const buttonClasses = (variant: ButtonVariant = 'primary') => `${base} ${variants[variant]}`;
 
 /** {@link Button} の props。標準の button 属性に見た目バリアントを加えたもの。 */
 type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {

--- a/front/src/components/ui/LoadingSpinner.tsx
+++ b/front/src/components/ui/LoadingSpinner.tsx
@@ -34,7 +34,8 @@ const modeClasses: Record<LoadingMode, string> = {
 };
 
 const variantClasses: Record<LoadingVariant, string> = {
-  block: 'flex items-center justify-center gap-2 rounded-2xl bg-gray-50 px-4 py-3 text-sm font-bold',
+  block:
+    'flex items-center justify-center gap-2 rounded-2xl bg-gray-50 px-4 py-3 text-sm font-bold',
   inline: 'inline-flex items-center gap-2 text-sm font-bold',
 };
 

--- a/front/src/components/ui/PageHeader.tsx
+++ b/front/src/components/ui/PageHeader.tsx
@@ -22,24 +22,19 @@ type PageHeaderProps = {
  * ページ上部に固定表示するヘッダー。タイトル・補助ラベル・右側アクションを配置する。
  * props の各項目は {@link PageHeaderProps} を参照。
  */
-export default function PageHeader({
-  title,
-  subtitle,
-  action,
-  maxWidth = '5xl',
-}: PageHeaderProps) {
+export default function PageHeader({ title, subtitle, action, maxWidth = '5xl' }: PageHeaderProps) {
   return (
     <div className="sticky top-0 z-10 border-b bg-white/80 px-6 py-4 backdrop-blur">
-      <div className={`mx-auto flex ${widthMap[maxWidth]} flex-wrap items-center justify-between gap-4`}>
+      <div
+        className={`mx-auto flex ${widthMap[maxWidth]} flex-wrap items-center justify-between gap-4`}
+      >
         <div>
           {subtitle ? (
             <p className="text-[10px] font-black uppercase tracking-[0.2em] text-gray-400">
               {subtitle}
             </p>
           ) : null}
-          <h1 className="text-2xl font-black tracking-tight text-[color:var(--accent)]">
-            {title}
-          </h1>
+          <h1 className="text-2xl font-black tracking-tight text-[color:var(--accent)]">{title}</h1>
         </div>
         {action}
       </div>

--- a/front/src/lib/adminAuth.ts
+++ b/front/src/lib/adminAuth.ts
@@ -5,14 +5,10 @@ const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '';
 const adminEmail = process.env.ADMIN_EMAIL?.trim().toLowerCase() ?? '';
 
-const isE2eBypass =
-  process.env.NODE_ENV !== 'production' &&
-  process.env.E2E_BYPASS === '1';
+const isE2eBypass = process.env.NODE_ENV !== 'production' && process.env.E2E_BYPASS === '1';
 
 /** 管理者認証の結果。未認可時は呼び出し側がそのまま返せる `response` を同梱する。 */
-type AuthResult =
-  | { authorized: true }
-  | { authorized: false; response: NextResponse };
+type AuthResult = { authorized: true } | { authorized: false; response: NextResponse };
 
 /**
  * 書き込み系 API の管理者認証ガード（防御の第 1 層）。
@@ -33,10 +29,7 @@ export async function requireAdmin(request: Request): Promise<AuthResult> {
   if (!supabaseUrl || !supabaseAnonKey || !adminEmail) {
     return {
       authorized: false,
-      response: NextResponse.json(
-        { error: 'admin auth is not configured' },
-        { status: 500 },
-      ),
+      response: NextResponse.json({ error: 'admin auth is not configured' }, { status: 500 }),
     };
   }
 

--- a/front/src/lib/authFetch.ts
+++ b/front/src/lib/authFetch.ts
@@ -10,10 +10,7 @@ import { supabase } from '@/lib/supabase';
  * @param options - `fetch` に渡すオプション。既存の `headers` は保持したうえで認証ヘッダーを追加する
  * @returns `fetch` のレスポンス
  */
-export async function authFetch(
-  url: string,
-  options: RequestInit = {},
-): Promise<Response> {
+export async function authFetch(url: string, options: RequestInit = {}): Promise<Response> {
   const headers = new Headers(options.headers);
 
   const { data } = await supabase.auth.getSession();

--- a/front/src/lib/calorie.ts
+++ b/front/src/lib/calorie.ts
@@ -26,11 +26,7 @@ export const cardioMets: Record<string, number> = {
  * @param type - 有酸素種別。`cardioMets` に無い値は消費カロリー 0 とみなす
  * @returns 推定消費カロリー（kcal、丸め前の実数）
  */
-export const calculateCardioCalories = (
-  weightKg: number,
-  minutes: number,
-  type: CardioType,
-) => {
+export const calculateCardioCalories = (weightKg: number, minutes: number, type: CardioType) => {
   const mets = cardioMets[type] ?? 0;
   const hours = minutes / 60;
   return mets * weightKg * hours;

--- a/front/tests/e2e/helpers.ts
+++ b/front/tests/e2e/helpers.ts
@@ -30,8 +30,14 @@ export const selectDate = async (page: Page, dateStr: string) => {
 
   const popup = page.locator('.absolute.top-full');
   await popup.locator('select').nth(0).selectOption(String(year));
-  await popup.locator('select').nth(1).selectOption(String(month - 1));
-  await popup.getByRole('button', { name: String(day), exact: true }).first().click();
+  await popup
+    .locator('select')
+    .nth(1)
+    .selectOption(String(month - 1));
+  await popup
+    .getByRole('button', { name: String(day), exact: true })
+    .first()
+    .click();
 };
 
 // ---------------------------------------------------------------------------

--- a/front/tests/e2e/record-crud.spec.ts
+++ b/front/tests/e2e/record-crud.spec.ts
@@ -18,7 +18,9 @@ test.beforeEach(async () => {
 // 認証ガード
 // ---------------------------------------------------------------------------
 
-test('should redirect to /admin/login when accessing admin page without login', async ({ page }) => {
+test('should redirect to /admin/login when accessing admin page without login', async ({
+  page,
+}) => {
   await page.goto('/admin/records/new');
   await expect(page).toHaveURL(/\/admin\/login/);
 });
@@ -179,7 +181,9 @@ test('should add and remove multiple cardio rows', async ({ page }) => {
   const cardioSelects = page.locator('select').filter({ hasText: 'ラン' });
   await expect(cardioSelects).toHaveCount(2);
 
-  const cardioRows = page.locator('.rounded-2xl').filter({ has: page.locator('option[value="ウォーク"]') });
+  const cardioRows = page
+    .locator('.rounded-2xl')
+    .filter({ has: page.locator('option[value="ウォーク"]') });
   await cardioRows.last().getByRole('button', { name: '削除' }).click();
   await expect(cardioSelects).toHaveCount(1);
 });
@@ -197,7 +201,11 @@ test('should delete a record from the admin list', async ({ page }) => {
   await expect(page.getByText('2026-02-02')).toBeVisible();
 
   // 2026-02-02 のカード内の削除ボタンを押す。
-  const card = page.locator('div').filter({ hasText: '2026-02-02' }).filter({ has: page.getByRole('button', { name: '削除' }) }).last();
+  const card = page
+    .locator('div')
+    .filter({ hasText: '2026-02-02' })
+    .filter({ has: page.getByRole('button', { name: '削除' }) })
+    .last();
   await card.getByRole('button', { name: '削除' }).click();
 
   // 実 DB から消え、一覧から 2026-02-02 が消える（2026-01-15 は残る）。

--- a/front/tests/e2e/smoke.spec.ts
+++ b/front/tests/e2e/smoke.spec.ts
@@ -1,10 +1,5 @@
 import { expect, test } from '@playwright/test';
-import {
-  injectAdminSession,
-  resetDb,
-  resetAndSeedBaseline,
-  seedRecordsForDates,
-} from './helpers';
+import { injectAdminSession, resetDb, resetAndSeedBaseline, seedRecordsForDates } from './helpers';
 
 // 実 DB（docker-compose.e2e.yml）に seed したデータで主要画面の描画を検証する。
 

--- a/front/tests/it/app/api/masters/route.it.test.ts
+++ b/front/tests/it/app/api/masters/route.it.test.ts
@@ -52,7 +52,10 @@ describe('IT: /api/masters (実 DB)', () => {
     expect(patched.status).toBe(200);
     expect((await patched.json()).name).toBe('スクワット');
 
-    const del = await deleteMaster(new NextRequest('http://localhost', { method: 'DELETE' }), makeContext(created.id));
+    const del = await deleteMaster(
+      new NextRequest('http://localhost', { method: 'DELETE' }),
+      makeContext(created.id),
+    );
     expect(del.status).toBe(200);
 
     const prisma = getPrisma()!;
@@ -87,7 +90,10 @@ describe('IT: /api/masters (実 DB)', () => {
   // --- 異常系 ---
 
   it('should return 404 when updating a non-existent master id', async () => {
-    const req = new NextRequest('http://localhost', { method: 'PATCH', body: JSON.stringify({ name: 'x' }) });
+    const req = new NextRequest('http://localhost', {
+      method: 'PATCH',
+      body: JSON.stringify({ name: 'x' }),
+    });
     const res = await updateMaster(req, makeContext('nonexistent-id'));
     expect(res.status).toBe(404);
   });

--- a/front/tests/it/app/api/records/route.it.test.ts
+++ b/front/tests/it/app/api/records/route.it.test.ts
@@ -158,7 +158,10 @@ describe('IT: PATCH/DELETE /api/records/[date] (実 DB)', () => {
   it('should delete a record and cascade-remove its workouts/cardios', async () => {
     await createRecord(createRequest(sampleBody('2026-06-01')));
 
-    const del = await deleteRecord(new Request('http://localhost', { method: 'DELETE' }), makeContext('2026-06-01'));
+    const del = await deleteRecord(
+      new Request('http://localhost', { method: 'DELETE' }),
+      makeContext('2026-06-01'),
+    );
     expect(del.status).toBe(200);
     expect(await del.json()).toEqual({ ok: true });
 
@@ -172,13 +175,19 @@ describe('IT: PATCH/DELETE /api/records/[date] (実 DB)', () => {
   // --- 準正常系 ---
 
   it('should return 404 when patching a non-existent date', async () => {
-    const req = new Request('http://localhost', { method: 'PATCH', body: JSON.stringify({ memo: 'x' }) });
+    const req = new Request('http://localhost', {
+      method: 'PATCH',
+      body: JSON.stringify({ memo: 'x' }),
+    });
     const res = await patchRecord(req, makeContext('2099-01-01'));
     expect(res.status).toBe(404);
   });
 
   it('should return 404 when deleting a non-existent date', async () => {
-    const res = await deleteRecord(new Request('http://localhost', { method: 'DELETE' }), makeContext('2099-01-01'));
+    const res = await deleteRecord(
+      new Request('http://localhost', { method: 'DELETE' }),
+      makeContext('2099-01-01'),
+    );
     expect(res.status).toBe(404);
   });
 });

--- a/front/tests/scenario/admin-lifecycle.spec.ts
+++ b/front/tests/scenario/admin-lifecycle.spec.ts
@@ -1,9 +1,5 @@
 import { expect, test } from '@playwright/test';
-import {
-  injectAdminSession,
-  selectDate,
-  resetAndSeedBaseline,
-} from '../e2e/helpers';
+import { injectAdminSession, selectDate, resetAndSeedBaseline } from '../e2e/helpers';
 
 // シナリオ: 管理者による記録の一気通貫ライフサイクル。
 // 追加 → 一覧で確認 → 詳細 → 編集 → 詳細で反映確認 → 削除 → 一覧から消滅、を

--- a/front/tests/scenario/profile-calorie.spec.ts
+++ b/front/tests/scenario/profile-calorie.spec.ts
@@ -12,7 +12,9 @@ test.beforeEach(async () => {
   await resetAndSeedBaseline();
 });
 
-test('changing profile weight updates the estimated calories on the detail page', async ({ page }) => {
+test('changing profile weight updates the estimated calories on the detail page', async ({
+  page,
+}) => {
   await injectAdminSession(page);
 
   // 体重を 100kg に設定

--- a/front/tests/scenario/visitor-browsing.spec.ts
+++ b/front/tests/scenario/visitor-browsing.spec.ts
@@ -1,9 +1,5 @@
 import { expect, test } from '@playwright/test';
-import {
-  resetDb,
-  seedBaseline,
-  seedRecordsForDates,
-} from '../e2e/helpers';
+import { resetDb, seedBaseline, seedRecordsForDates } from '../e2e/helpers';
 
 // シナリオ: 一般訪問者（非管理者）の閲覧回遊。
 // 一覧 → ページング → 詳細（カロリー表示）を辿り、管理者操作が一切出ないことを確認する。
@@ -17,7 +13,9 @@ test.beforeEach(async () => {
   );
 });
 
-test('a visitor browses the list, paginates, and opens a detail without admin controls', async ({ page }) => {
+test('a visitor browses the list, paginates, and opens a detail without admin controls', async ({
+  page,
+}) => {
   // 1) 一覧: 管理者ログイン導線はあるが、管理者専用（記録追加）は出ない
   await page.goto('/');
   await expect(page.getByRole('heading', { name: '記録一覧' })).toBeVisible();

--- a/front/tests/unit/app/api/admin/me/route.test.ts
+++ b/front/tests/unit/app/api/admin/me/route.test.ts
@@ -17,9 +17,7 @@ const ADMIN_EMAIL = 'admin@example.com';
  *
  * @returns 再評価した route モジュール（`GET` を含む）
  */
-const loadRoute = async (
-  env: { url?: string; anon?: string; admin?: string } = {},
-) => {
+const loadRoute = async (env: { url?: string; anon?: string; admin?: string } = {}) => {
   vi.resetModules();
   vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', env.url ?? 'https://dummy.supabase.co');
   vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', env.anon ?? 'dummy-anon-key');
@@ -53,7 +51,10 @@ describe('GET /api/admin/me', () => {
   });
 
   it('should match ADMIN_EMAIL case-insensitively and trimming whitespace', async () => {
-    mockGetUser.mockResolvedValue({ data: { user: { email: '  ADMIN@Example.com ' } }, error: null });
+    mockGetUser.mockResolvedValue({
+      data: { user: { email: '  ADMIN@Example.com ' } },
+      error: null,
+    });
     const { GET } = await loadRoute();
 
     const res = await GET(bearerRequest('valid-token'));

--- a/front/tests/unit/app/api/records/[date]/route.test.ts
+++ b/front/tests/unit/app/api/records/[date]/route.test.ts
@@ -86,7 +86,10 @@ describe('GET /api/records/[date]', () => {
 describe('PATCH /api/records/[date]', () => {
   it('should return 503 when database is unavailable', async () => {
     vi.mocked(getPrisma).mockReturnValue(null);
-    const req = new Request('http://localhost', { method: 'PATCH', body: JSON.stringify({ memo: 'ok' }) });
+    const req = new Request('http://localhost', {
+      method: 'PATCH',
+      body: JSON.stringify({ memo: 'ok' }),
+    });
     const res = await PATCH(req, makeContext('2026-01-01'));
     expect(res.status).toBe(503);
   });
@@ -96,7 +99,10 @@ describe('PATCH /api/records/[date]', () => {
     vi.mocked(prisma.exerciseRecord.findUnique).mockResolvedValue(null);
     vi.mocked(getPrisma).mockReturnValue(prisma as never);
 
-    const req = new Request('http://localhost', { method: 'PATCH', body: JSON.stringify({ memo: 'ok' }) });
+    const req = new Request('http://localhost', {
+      method: 'PATCH',
+      body: JSON.stringify({ memo: 'ok' }),
+    });
     const res = await PATCH(req, makeContext('2099-01-01'));
     expect(res.status).toBe(404);
   });
@@ -120,7 +126,10 @@ describe('PATCH /api/records/[date]', () => {
     const prisma = makePrisma();
     vi.mocked(getPrisma).mockReturnValue(prisma as never);
 
-    const req = new Request('http://localhost', { method: 'PATCH', body: JSON.stringify({ memo: 'ok' }) });
+    const req = new Request('http://localhost', {
+      method: 'PATCH',
+      body: JSON.stringify({ memo: 'ok' }),
+    });
     const res = await PATCH(req, makeContext('2026-01-01'));
     expect(res.status).toBe(401);
   });

--- a/front/tests/unit/app/api/records/route.test.ts
+++ b/front/tests/unit/app/api/records/route.test.ts
@@ -51,7 +51,11 @@ describe('GET /api/records', () => {
     const prisma = makePrisma();
     vi.mocked(prisma.exerciseRecord.count).mockResolvedValue(2);
     vi.mocked(prisma.exerciseRecord.findMany).mockResolvedValue([
-      { date: new Date('2026-01-02'), workouts: [{ sets: 3 }], cardios: [{ type: 'ラン', minutes: 30, distance: 5 }] },
+      {
+        date: new Date('2026-01-02'),
+        workouts: [{ sets: 3 }],
+        cardios: [{ type: 'ラン', minutes: 30, distance: 5 }],
+      },
       { date: new Date('2026-01-01'), workouts: [{ sets: 5 }], cardios: [] },
     ] as never);
     vi.mocked(getPrisma).mockReturnValue(prisma as never);

--- a/front/tests/unit/hooks/useRecordValidation.test.ts
+++ b/front/tests/unit/hooks/useRecordValidation.test.ts
@@ -22,9 +22,7 @@ describe('useRecordValidation', () => {
   // --- 正常系 ---
 
   it('should initialize with submitted=false and empty displayErrors', () => {
-    const { result } = renderHook(() =>
-      useRecordValidation('', [validWorkout], []),
-    );
+    const { result } = renderHook(() => useRecordValidation('', [validWorkout], []));
     expect(result.current.submitted).toBe(false);
     expect(result.current.displayErrors).toEqual({ workouts: {}, cardios: {} });
   });
@@ -37,9 +35,7 @@ describe('useRecordValidation', () => {
   });
 
   it('should expose errors in displayErrors after setSubmitted(true)', () => {
-    const { result } = renderHook(() =>
-      useRecordValidation('', [validWorkout], []),
-    );
+    const { result } = renderHook(() => useRecordValidation('', [validWorkout], []));
     act(() => {
       result.current.setSubmitted(true);
     });
@@ -49,25 +45,19 @@ describe('useRecordValidation', () => {
   // --- 準正常系 ---
 
   it('should hide errors in displayErrors before submission even if rawErrors exist', () => {
-    const { result } = renderHook(() =>
-      useRecordValidation('', [validWorkout], []),
-    );
+    const { result } = renderHook(() => useRecordValidation('', [validWorkout], []));
     expect(result.current.rawErrors.date).toBe('日付を選択してください');
     expect(result.current.displayErrors.date).toBeUndefined();
   });
 
   it('should return hasErrors=true when date is missing', () => {
-    const { result } = renderHook(() =>
-      useRecordValidation('', [validWorkout], []),
-    );
+    const { result } = renderHook(() => useRecordValidation('', [validWorkout], []));
     expect(result.current.hasErrors).toBe(true);
   });
 
   it('should reactively update rawErrors when inputs change', () => {
     let date = '';
-    const { result, rerender } = renderHook(() =>
-      useRecordValidation(date, [validWorkout], []),
-    );
+    const { result, rerender } = renderHook(() => useRecordValidation(date, [validWorkout], []));
     expect(result.current.rawErrors.date).toBe('日付を選択してください');
 
     date = '2026-01-01';
@@ -78,9 +68,7 @@ describe('useRecordValidation', () => {
   // --- 異常系 ---
 
   it('should handle empty workouts array without throwing', () => {
-    const { result } = renderHook(() =>
-      useRecordValidation('2026-01-01', [], []),
-    );
+    const { result } = renderHook(() => useRecordValidation('2026-01-01', [], []));
     expect(result.current.hasErrors).toBe(false);
     expect(result.current.rawErrors.workouts).toEqual({});
   });

--- a/front/tests/unit/lib/calorie.test.ts
+++ b/front/tests/unit/lib/calorie.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  calculateCardioCalories,
-  calculateStrengthCalories,
-  formatCalories,
-} from '@/lib/calorie';
+import { calculateCardioCalories, calculateStrengthCalories, formatCalories } from '@/lib/calorie';
 
 describe('calculateCardioCalories', () => {
   // --- 正常系 ---

--- a/front/tests/unit/lib/validation.test.ts
+++ b/front/tests/unit/lib/validation.test.ts
@@ -194,7 +194,14 @@ describe('computeErrors', () => {
   });
 
   it('should only report errors for the invalid workout row when multiple rows exist', () => {
-    const workout2 = { id: 'w2', part: '', name: 'スクワット', sets: '3', reps: '10', weight: '80' };
+    const workout2 = {
+      id: 'w2',
+      part: '',
+      name: 'スクワット',
+      sets: '3',
+      reps: '10',
+      weight: '80',
+    };
     const errors = computeErrors('2026-01-01', [validWorkout, workout2], []);
     expect(errors.workouts['w1']).toBeUndefined();
     expect(errors.workouts['w2'].part).toBe('部位を選択してください');


### PR DESCRIPTION
## 概要

`.claude/rules/static-analysis.md` は「**Formatter は差分ゼロを検証する（`--check` 系）**」「Linter・Formatter・型チェックはすべて CI で実行する」と定めているが、`pnpm format` が CI に入っておらずローカル任意実行になっていた。ルールに実装を合わせる。

Closes #87

## コミットを 3 つに分けている

**整形差分（36 ファイル）だけを独立したコミットにしてある**ので、レビューは 1 と 3 だけ見れば足りる。

| # | コミット | 内容 | レビュー |
|---|---|---|---|
| 1 | `chore(prettier)` | `.prettierignore` に生成物を追加 | **要** |
| 2 | `style` | **一括整形のみ（36 ファイル）** | 不要 |
| 3 | `chore(ci)` | CI に `pnpm format` 追加・ルール/ドキュメント同期 | **要** |

## 1. `.prettierignore` の整備

CI で `prettier --check .` を必須にすると、**ローカルに生成物が残っているだけで検査が落ちる**。実際 `test-results/.last-run.json`（Playwright の実行成果物、`.gitignore` 済み）が検出されていた。

追加した除外: `src/generated` / `test-results` / `playwright-report` / `coverage`

## 2. 一括整形（36 ファイル）

`printWidth: 100` / `singleQuote: true` の既存 `.prettierrc` に従って整形した。

**意味変更がないことを機械的に検証している。** 全ファイルについて識別子・文字列リテラル・数値の**出現回数を照合**し、差異が出た 4 ファイルはいずれも引用符スタイル（`"x"` → `'x'`）のみであることを確認した。残る 32 ファイルはトークン完全一致（行の再フローのみ）。

差分を目視で追う必要はない。整形の正しさは Prettier が保証し、動作は下記の検証が保証する。

## 3. CI への追加

```yaml
- name: Format check (Prettier)
  run: pnpm format
- name: Lint (ESLint)
  run: pnpm lint
```

**lint より前に置いた。** 整形起因のノイズを先に弾いた方が、落ちたときの原因が分かりやすいため。

`--check` のみで、**CI が自動整形してコミットし返す運用は採らない**（`static-analysis.md`）。

## 動作確認

| | 結果 |
|---|---|
| `pnpm format` | `All matched files use Prettier code style!` |
| `pnpm lint` | エラーなし |
| `pnpm exec tsc --noEmit` | エラーなし |
| `pnpm test` | 11 files / **144 tests passed**（整形前後で同結果） |
| `markdownlint-cli2@0.23.1` | `0 issues` |
| `ci.yml` | YAML パース検証済み |

## ドキュメント同期（`.claude/rules/documentation.md` 影響マップ）

- `static-analysis.md` — **「未達の項目」注記を削除**。設定ファイルの所在と `format` / `format:fix` の使い分けを追記
- `README.md` — 開発コマンドに `pnpm run format:fix` を追加（`pnpm format` が落ちたときの導線）
- `docs/09-architecture-specification.md` — `static-check` ジョブの内訳を同期

## 補足

これで `static-analysis.md` の「CI で必須にする」項目（Linter / Formatter / 型チェック）が**すべて CI で担保**された状態になる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)