### PR TITLE
fix(api): masters のレスポンスから監査カラムを除外する

### DIFF
--- a/docs/07-api-specification.md
+++ b/docs/07-api-specification.md
@@ -96,6 +96,8 @@
 ### マスター管理
 
 - `GET /masters?type=body-parts|exercises|cardio-types` / `POST /masters?type=...` / `PATCH /masters/:id` / `DELETE /masters/:id`。
+- レスポンス（`DELETE` を除く）は **`{ id, name, type }` のみ**。`createdAt` / `updatedAt` は公開しない（`.claude/rules/api.md`「レスポンス整形」）。契約型は `front/src/types/master.ts` の `MasterResponse` で、Route Handler と画面が共有する。
+- `PATCH` は、DB に保存されている `type` が既知の種別でない場合に 500 `{ error: "invalid master type in database" }` を返す（`type` は制約なしの `String` 列のため）。
 
 ### プロフィール
 

--- a/docs/test-design/test-design.md
+++ b/docs/test-design/test-design.md
@@ -244,8 +244,8 @@ pnpm add -D vitest @vitejs/plugin-react @testing-library/react @testing-library/
 
 | テストファイル | 対象 | 件数 | 主な正常/準正常/異常 |
 |---|---|---|---|
-| `tests/unit/app/api/masters/route.test.ts` | GET / POST | 12 | 正: 一覧(name昇順)・作成 / 準: type不正400・name欠落400・重複409 / 異: 未認証401・503 |
-| `tests/unit/app/api/masters/[id]/route.test.ts` | PATCH / DELETE | 9 | 正: 更新・削除 / 準: name欠落400・not found404 / 異: 未認証401・503 |
+| `tests/unit/app/api/masters/route.test.ts` | GET / POST | 13 | 正: 一覧(name昇順)・作成 / 準: type不正400・name欠落400・重複409・**監査カラム非公開** / 異: 未認証401・503 |
+| `tests/unit/app/api/masters/[id]/route.test.ts` | PATCH / DELETE | 11 | 正: 更新・削除 / 準: name欠落400・not found404・**監査カラム非公開** / 異: 未認証401・503・**DB の type 不正500** |
 | `tests/unit/app/api/profile/route.test.ts` | GET / POST | 12 | 正: 取得・上書き(update+deleteMany)・新規create / 準: 未存在null・weightKg非数値400 / 異: 未認証401・DBエラー握りつぶし・503相当 |
 | `tests/unit/app/api/admin/me/route.test.ts` | GET | 8 | 正: 管理者200(大小文字/前後空白許容) / 準: トークン欠落401・無効401・非管理者403 / 異: 認証設定不備500 |
 | `tests/unit/app/api/admin/export/route.test.ts` | GET | 11 | 正: CSV横並び展開・escape・空展開・JSON / 準: from/to欠落400・format不正400・空文字400 / 異: 未認証401・403・503 |

--- a/front/src/app/admin/masters/page.tsx
+++ b/front/src/app/admin/masters/page.tsx
@@ -8,7 +8,7 @@ import PageHeader from '@/components/ui/PageHeader';
 import { buttonClasses } from '@/components/ui/Button';
 import LoadingSpinner from '@/components/ui/LoadingSpinner';
 import { authFetch } from '@/lib/authFetch';
-import { MASTER_TYPES, type MasterType } from '@/types/master';
+import { MASTER_TYPES, type MasterResponse, type MasterType } from '@/types/master';
 
 /**
  * マスター種別ごとの表示ラベル。**表示は UI の関心事**のため、種別の定義
@@ -26,16 +26,6 @@ const masterTabs = MASTER_TYPES.map((type) => ({
   label: MASTER_TYPE_LABELS[type],
 }));
 
-/** マスター項目 1 件を表す。 */
-type MasterItem = {
-  /** 項目の一意 ID。 */
-  id: string;
-  /** 項目の名称（一覧表示・編集対象）。 */
-  name: string;
-  /** 所属するマスター種別。 */
-  type: MasterType;
-};
-
 /**
  * マスター管理画面。部位・種目・有酸素種別のタブを切り替えて項目を一覧表示し、追加・
  * インライン編集・削除（確認ダイアログ付き）を行う。取得・追加・保存・削除は API 経由で、
@@ -43,7 +33,7 @@ type MasterItem = {
  */
 export default function AdminMastersPage() {
   const [activeType, setActiveType] = useState<MasterType>('body-parts');
-  const [items, setItems] = useState<MasterItem[]>([]);
+  const [items, setItems] = useState<MasterResponse[]>([]);
   const [inputValue, setInputValue] = useState('');
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingValue, setEditingValue] = useState('');
@@ -68,7 +58,7 @@ export default function AdminMastersPage() {
         setLoading(false);
         return;
       }
-      const data = (await res.json()) as MasterItem[];
+      const data = (await res.json()) as MasterResponse[];
       setItems(data);
       setLoading(false);
     };
@@ -98,7 +88,7 @@ export default function AdminMastersPage() {
         return;
       }
 
-      const created = (await res.json()) as MasterItem;
+      const created = (await res.json()) as MasterResponse;
       setItems((prev) => [created, ...prev]);
       setInputValue('');
     } finally {
@@ -106,7 +96,7 @@ export default function AdminMastersPage() {
     }
   };
 
-  const handleEdit = (item: MasterItem) => {
+  const handleEdit = (item: MasterResponse) => {
     setEditingId(item.id);
     setEditingValue(item.name);
   };

--- a/front/src/app/api/masters/[id]/route.ts
+++ b/front/src/app/api/masters/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getPrisma } from '@/lib/prisma';
 import { requireAdmin } from '@/lib/adminAuth';
+import { MASTER_SELECT, isMasterType, type MasterResponse } from '@/types/master';
 
 /** マスター編集・削除ハンドラーのルートコンテキスト。`params` に対象マスターの `id` を含む。 */
 type RouteContext = {
@@ -38,8 +39,17 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
     const updated = await prisma.exerciseMaster.update({
       where: { id },
       data: { name },
+      select: MASTER_SELECT,
     });
-    return NextResponse.json(updated);
+
+    // DB の type は制約なしの String 列で、更新対象の種別はリクエストから分からない。
+    // 想定外の値が保存されていた場合に union として偽らず、500 で落とす。
+    if (!isMasterType(updated.type)) {
+      return NextResponse.json({ error: 'invalid master type in database' }, { status: 500 });
+    }
+
+    const result: MasterResponse = { id: updated.id, name: updated.name, type: updated.type };
+    return NextResponse.json(result);
   } catch {
     return NextResponse.json({ error: 'not found or duplicate' }, { status: 404 });
   }

--- a/front/src/app/api/masters/route.ts
+++ b/front/src/app/api/masters/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getPrisma } from '@/lib/prisma';
 import { requireAdmin } from '@/lib/adminAuth';
-import { isMasterType } from '@/types/master';
+import { MASTER_SELECT, isMasterType, type MasterResponse } from '@/types/master';
 
 /**
  * 指定種別のマスター（部位・種目・有酸素種別）を名称昇順で一覧取得する。
@@ -24,12 +24,19 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'invalid type' }, { status: 400 });
   }
 
+  // select で公開列を確定する。スキーマにカラムが増えても自動公開されない
+  // （.claude/rules/api.md「レスポンス整形」）。
   const masters = await prisma.exerciseMaster.findMany({
     where: { type },
     orderBy: { name: 'asc' },
+    select: MASTER_SELECT,
   });
 
-  return NextResponse.json(masters);
+  // DB の type は制約なしの String 列のため Prisma の戻り値は MasterType に狭まらない。
+  // ここでは where で絞り込んだ検証済みの type を使うので、返す値は必ずその種別になる。
+  const result: MasterResponse[] = masters.map(({ id, name }) => ({ id, name, type }));
+
+  return NextResponse.json(result);
 }
 
 /**
@@ -66,8 +73,11 @@ export async function POST(request: Request) {
   try {
     const master = await prisma.exerciseMaster.create({
       data: { type, name },
+      select: MASTER_SELECT,
     });
-    return NextResponse.json(master);
+    // GET と同じ理由で、検証済みの type を使って組み立てる。
+    const result: MasterResponse = { id: master.id, name: master.name, type };
+    return NextResponse.json(result);
   } catch {
     return NextResponse.json({ error: 'duplicate' }, { status: 409 });
   }

--- a/front/src/types/master.ts
+++ b/front/src/types/master.ts
@@ -14,6 +14,29 @@ export const MASTER_TYPES = ['body-parts', 'exercises', 'cardio-types'] as const
 export type MasterType = (typeof MASTER_TYPES)[number];
 
 /**
+ * マスター 1 件の API 契約。`/api/masters` 系が返す形で、Route Handler と画面が共有する。
+ *
+ * `ExerciseMaster` の全カラムではなく**画面が必要とする項目だけ**を持つ。監査カラム
+ * （`createdAt` / `updatedAt`）は公開しない（`.claude/rules/api.md`「レスポンス整形」）。
+ */
+export type MasterResponse = {
+  /** 項目の一意 ID。編集・削除の対象指定に使う */
+  id: string;
+  /** 項目の名称。一覧表示と編集の対象。前後の空白は保存時に除去済み */
+  name: string;
+  /** 所属するマスター種別 */
+  type: MasterType;
+};
+
+/**
+ * `MasterResponse` を返すための Prisma `select`。
+ *
+ * `MasterResponse` と**必ず対で変わる**ため同じファイルに置く。列を足すときは
+ * 両方を更新する（型だけ足すと `satisfies` で、select だけ足すと未使用で気づける）。
+ */
+export const MASTER_SELECT = { id: true, name: true, type: true } as const;
+
+/**
  * 値が有効なマスター種別かを判定する。API のクエリ検証に使う。
  *
  * @param value - 判定対象。未指定のクエリを想定して `null` を許容する

--- a/front/tests/unit/app/api/masters/[id]/route.test.ts
+++ b/front/tests/unit/app/api/masters/[id]/route.test.ts
@@ -11,6 +11,7 @@ vi.mock('@/lib/adminAuth', () => ({
 }));
 
 import { getPrisma } from '@/lib/prisma';
+import { MASTER_SELECT } from '@/types/master';
 import { requireAdmin } from '@/lib/adminAuth';
 import type { NextRequest } from 'next/server';
 
@@ -51,10 +52,54 @@ describe('PATCH /api/masters/[id]', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toEqual({ id: 'm-1', type: 'body-parts', name: '大胸筋' });
+    // select で公開列を確定していること（監査カラムを返さない）を検証する。
     expect(prisma.exerciseMaster.update).toHaveBeenCalledWith({
       where: { id: 'm-1' },
       data: { name: '大胸筋' },
+      select: MASTER_SELECT,
     });
+  });
+
+  // 準正常系: Prisma が監査カラムを返しても、レスポンスには載せない。
+  // select による絞り込みが外れた場合の保険として、詰め替え側の挙動を固定する。
+  it('should not expose audit columns even if the row carries them', async () => {
+    const prisma = makePrisma();
+    vi.mocked(prisma.exerciseMaster.update).mockResolvedValue({
+      id: 'm-1',
+      type: 'body-parts',
+      name: '大胸筋',
+      createdAt: new Date('2026-01-01'),
+      updatedAt: new Date('2026-01-02'),
+    } as never);
+    vi.mocked(getPrisma).mockReturnValue(prisma as never);
+
+    const req = new Request('http://localhost', {
+      method: 'PATCH',
+      body: JSON.stringify({ name: '大胸筋' }),
+    });
+    const res = await PATCH(req as NextRequest, makeContext('m-1'));
+    const body = await res.json();
+    expect(Object.keys(body).sort()).toEqual(['id', 'name', 'type']);
+  });
+
+  // 異常系: DB の type は制約なしの String 列のため、想定外の値が入り得る。
+  // union として偽らず 500 で落とすことを固定する。
+  it('should return 500 when the stored type is not a known master type', async () => {
+    const prisma = makePrisma();
+    vi.mocked(prisma.exerciseMaster.update).mockResolvedValue({
+      id: 'm-1',
+      type: 'unknown-type',
+      name: '大胸筋',
+    } as never);
+    vi.mocked(getPrisma).mockReturnValue(prisma as never);
+
+    const req = new Request('http://localhost', {
+      method: 'PATCH',
+      body: JSON.stringify({ name: '大胸筋' }),
+    });
+    const res = await PATCH(req as NextRequest, makeContext('m-1'));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'invalid master type in database' });
   });
 
   it('should return 400 when name is blank after trimming', async () => {

--- a/front/tests/unit/app/api/masters/route.test.ts
+++ b/front/tests/unit/app/api/masters/route.test.ts
@@ -11,6 +11,7 @@ vi.mock('@/lib/adminAuth', () => ({
 }));
 
 import { getPrisma } from '@/lib/prisma';
+import { MASTER_SELECT } from '@/types/master';
 import { requireAdmin } from '@/lib/adminAuth';
 
 const makePrisma = () => ({
@@ -43,10 +44,32 @@ describe('GET /api/masters', () => {
     const body = await res.json();
     expect(body).toHaveLength(2);
     expect(body[0]).toEqual({ id: 'm-1', type: 'body-parts', name: '胸' });
+    // select で公開列を確定していること（監査カラムを返さない）を検証する。
     expect(prisma.exerciseMaster.findMany).toHaveBeenCalledWith({
       where: { type: 'body-parts' },
       orderBy: { name: 'asc' },
+      select: MASTER_SELECT,
     });
+  });
+
+  // 準正常系: Prisma が監査カラムを返しても、レスポンスには載せない。
+  // select による絞り込みが外れた場合の保険として、詰め替え側の挙動を固定する。
+  it('should not expose audit columns even if rows carry them', async () => {
+    const prisma = makePrisma();
+    vi.mocked(prisma.exerciseMaster.findMany).mockResolvedValue([
+      {
+        id: 'm-1',
+        type: 'body-parts',
+        name: '胸',
+        createdAt: new Date('2026-01-01'),
+        updatedAt: new Date('2026-01-02'),
+      },
+    ] as never);
+    vi.mocked(getPrisma).mockReturnValue(prisma as never);
+
+    const res = await GET(new Request('http://localhost/api/masters?type=body-parts'));
+    const body = await res.json();
+    expect(Object.keys(body[0]).sort()).toEqual(['id', 'name', 'type']);
   });
 
   it('should return 400 when type is invalid', async () => {
@@ -105,6 +128,7 @@ describe('POST /api/masters', () => {
     expect(body).toEqual({ id: 'm-9', type: 'exercises', name: 'ベンチプレス' });
     expect(prisma.exerciseMaster.create).toHaveBeenCalledWith({
       data: { type: 'exercises', name: 'ベンチプレス' },
+      select: MASTER_SELECT,
     });
   });
 
@@ -120,6 +144,7 @@ describe('POST /api/masters', () => {
     expect(res.status).toBe(200);
     expect(prisma.exerciseMaster.create).toHaveBeenCalledWith({
       data: { type: 'cardio-types', name: 'ランニング' },
+      select: MASTER_SELECT,
     });
   });
 


### PR DESCRIPTION
## 概要

`.claude/rules/api.md`「レスポンス整形（Prisma の行オブジェクトを素通ししない）」に違反し、`findMany` / `create` / `update` の戻り値をそのまま返していたため、**`createdAt` / `updatedAt` が意図せず公開されていた**。

Closes #94

## `admin/export` はスコープ外にした

#94 の対象 4 箇所のうち `api/admin/export/route.ts` は、**#20（データ出力機能の削除）で削除予定**のエンドポイント。#20 は OPEN かつ「使用しないため削除する」と明確なため、整形しても直後に消える作業になる。本 PR では触れず #20 に委ねる。

対応したのは masters の 3 箇所。

| ファイル | メソッド |
|---|---|
| `api/masters/route.ts` | GET / POST |
| `api/masters/[id]/route.ts` | PATCH |

## 変更内容

### 1. API 契約型を `types/` に定義して共有

```ts
// types/master.ts
export type MasterResponse = { id: string; name: string; type: MasterType };
export const MASTER_SELECT = { id: true, name: true, type: true } as const;
```

**`MasterResponse` と `MASTER_SELECT` は必ず対で変わる**ため同じファイルに置いた（`typescript.md`「型の元になる定数は型と同じファイルに置く」と同じ理屈）。列を足すときは両方を更新する必要があり、**型だけ足せば `satisfies` 相当の代入で、select だけ足せば未使用で気づける**。

画面側のローカル型 `MasterItem` は廃止し、`MasterResponse` を共有するようにした（`frontend.md`「型の扱い」— 変換は Route Handler に閉じ、フロントで再定義しない）。

### 2. `select` で公開列を確定し、明示的に詰め替える

スプレッド（`{ ...record }`）で組み立てていないため、**スキーマにカラムが増えても自動公開されない**。

### 3. `type` の型付けで判明したこと

`select` を入れた時点で **`tsc` が型エラーを出した。** DB の `type` は制約なしの `String` 列のため、Prisma の戻り値は `MasterType` union に狭まらない。

対処を分けた:

| 箇所 | 対処 |
|---|---|
| GET / POST | **検証済みの `type` 変数を使って組み立てる**。`where` / `data` に渡した値そのものなので、返す値は必ずその種別になる |
| PATCH | 更新対象の種別はリクエストから分からないため、`isMasterType` で判定し、**想定外なら 500 を返す**（union として偽らない） |

型を通すためのキャストで押し切らず、**保証できるところは保証し、できないところは失敗させる**方針を採った。

## テスト（3 件追加、計 147 passed）

- **監査カラム非公開 × 2** — Prisma が `createdAt` / `updatedAt` を含む行を返しても、レスポンスのキーが `['id','name','type']` だけであることを検証。`select` の絞り込みが外れた場合の保険として、**詰め替え側の挙動を固定**している
- **DB の `type` 不正で 500 × 1** — 新設した異常系分岐

既存の `toHaveBeenCalledWith` に `select: MASTER_SELECT` を追加し、**`select` を外したら落ちる**ようにした。

## 動作確認

| | 結果 |
|---|---|
| `pnpm test` | 11 files / **147 tests passed**（144 + 新規 3） |
| `pnpm format` / `pnpm lint` / `tsc --noEmit` | 全て pass |
| `markdownlint-cli2@0.23.1` | `0 issues` |

## ドキュメント同期（`.claude/rules/documentation.md` 影響マップ）

- API の変更 → `docs/07-api-specification.md`（レスポンス形と 500 の追加を明記）
- テストケースの追加 → `docs/test-design/test-design.md`（件数 12→13 / 9→11 と観点）

## レビュー時の注意

**レスポンスから `createdAt` / `updatedAt` が消える破壊的変更**だが、画面側は `id` / `name` / `type` しか参照していないことを確認済み（`MasterItem` の定義と全利用箇所を確認）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)